### PR TITLE
Add Pipelines yaml

### DIFF
--- a/.jfrog-pipelines/pr.yaml
+++ b/.jfrog-pipelines/pr.yaml
@@ -1,0 +1,223 @@
+resources:
+  - name: terraform_provider_platform
+    type: GitRepo
+    configuration:
+      gitProvider: partnership_github
+      path: jfrog/terraform-provider-platform # if path is modified, change the name as well, per Pipelines doc
+      branches:
+        include: main
+      buildOn:
+        commit: false
+        pullRequestCreate: true
+      cancelPendingRunsOn:
+        pullRequestUpdate: false
+
+pipelines:
+  - name: tf_provider_platform
+    steps: build_and_run_tf_provider
+      type: Bash
+      configuration:
+        priority: 1
+        timeoutSeconds: 1200 # 20 minutes
+        runtime:
+          type: image
+          image:
+            auto:
+              language: go
+              versions:
+                - "1.19"
+        requiresApproval:
+          approvers:
+            - alexh
+            - danielmi
+          notifications:
+            - integrationName: partnership_slack
+          timeoutSeconds: 172800 # 2 days
+        integrations:
+          - name: partnership_slack
+          - name: partnership_github
+          - name: partnership_rt_cluster_license
+        inputResources:
+          - name: terraform_provider_platform
+        environmentVariables:
+          USE_LATEST_RT_VERSION: "true"
+          ARTIFACTORY_TEST_VERSION: 7.71.5
+      execution:
+        onStart:
+          - echo "Sending status to GitHub."
+          - export STATE="pending"
+          - export DESCRIPTION="Pipeline run is in progress."
+          - git clone https://${int_partnership_github_token}@github.com/jfrog/terraform-provider-shared.git
+          - ./terraform-provider-shared/scripts/github-status.sh ${res_terraform_provider_platform_gitProvider_token} ${res_terraform_provider_platform_gitRepoFullName} ${res_terraform_provider_platform_commitSha}
+          - echo "Preparing for work. Install Helm, Terraform, GoReleaser"
+          - ls -al && pwd
+          - echo "Helm 3 install"
+          - curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && chmod 700 get_helm.sh
+          - echo "Run Helm installation script" && ./get_helm.sh && rm get_helm.sh
+          - helm version
+          - sudo apt update
+          - go version
+          - echo "Install latest Terraform version"
+          - wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          - gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint
+          - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          - sudo apt update && apt-get install terraform && terraform -version
+          - add_run_variables TERRAFORM_VERSION=$(terraform -version | grep "Terraform v" | awk '{print $2}')
+          - echo "Install GoReleaser"
+          - echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+          - sudo apt update
+          - sudo apt install goreleaser
+        onExecute:
+          - add_run_variables TFProviderRepo=$(echo ${res_terraform_provider_platform_gitRepoRepositorySshUrl} | sed -e 's/git@/@/g' -e 's/:/\//g')
+          - cd ${res_terraform_provider_platform_resourcePath} # we need to manually move into the resource path
+          - echo "Verify the code contents merged feature branch with master branch (detached mode)"
+          - git branch && ls -al
+          - add_run_variables PROVIDER_VERSION=$(git describe --tags --abbrev=0 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
+          - echo "Provider version is ${PROVIDER_VERSION}"
+          - echo "Rename the build to make it work on Ubuntu"
+          - cat GNUmakefile | sed -e "s/darwin_amd64/linux_amd64/g" > GNUmakefile.tmp
+          - cp GNUmakefile.tmp GNUmakefile && rm GNUmakefile.tmp
+          - cat GNUmakefile
+          - cat sample.tf | sed -e "s/version =.*/version = \"${PROVIDER_VERSION}\"/g" > sample.tf.tmp
+          - cp sample.tf.tmp sample.tf && rm sample.tf.tmp
+          - cat sample.tf
+          - echo "Save RT licenses from the variable to the license file"
+          - echo ${int_partnership_rt_cluster_license_5licenses} > scripts/artifactory.lic
+          - echo "Set Artifactory version, run RT in a container"
+          - >-
+            if [[ ${USE_LATEST_RT_VERSION} == "true" ]]; then
+              helm repo add artifactory https://charts.jfrog.io
+              helm repo update
+              add_run_variables ARTIFACTORY_VERSION=$(helm search repo | grep "artifactory " | awk '{$1=$1};1' |  cut -f3 -d " ")
+              echo "Artifactory version: "${ARTIFACTORY_VERSION}
+            else
+              add_run_variables ARTIFACTORY_VERSION=${ARTIFACTORY_TEST_VERSION}
+              echo "Artifactory version: "${ARTIFACTORY_VERSION}
+            fi
+          - export ARTIFACTORY_CONTAINER_NAME=artifactory
+          - >-
+            docker run -i --name ${ARTIFACTORY_CONTAINER_NAME} -t -d --rm -v "${res_terraform_provider_platform_resourcePath}/scripts/artifactory.lic:/artifactory_extra_conf/artifactory.lic:ro" \
+              -p 8082:8082 releases-docker.jfrog.io/jfrog/artifactory-pro:${ARTIFACTORY_VERSION}
+          - echo "Set localhost to a container IP address, since we run docker inside of docker"
+          - export LOCALHOST=$(docker inspect -f '{{`{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}`}}' ${ARTIFACTORY_CONTAINER_NAME})
+          - echo "Using ${LOCALHOST} as 'localhost' ip address"
+          - echo "Waiting for Artifactory to start (doesn't reflect the start of the UI!)"
+          - export JFROG_URL="http://${LOCALHOST}:8082"
+          - >-
+            until curl -sf -u admin:password ${JFROG_URL}/artifactory/api/system/licenses/; do
+                printf '.'
+                sleep 4
+            done
+          - echo "Add variables needed to run Terraform Provider"
+          - export ARTIFACTORY_USERNAME=admin
+          - export ARTIFACTORY_PASSWORD=password
+          - echo "Get cookie to generate Access token. We need a pause to let UI come up to get cookies"
+          - >-
+            until curl -sf -u admin:password ${JFROG_URL}/ui/login/; do
+                printf '.'
+                sleep 4
+            done
+          - sudo curl ${JFROG_URL}/router/api/v1/system/health
+          - >-
+            export COOKIES=$(curl -c - "${JFROG_URL}/ui/api/v1/ui/auth/login?_spring_security_remember_me=false" \
+                          --header "accept: application/json, text/plain, */*" \
+                          --header "content-type: application/json;charset=UTF-8" \
+                          --header "x-requested-with: XMLHttpRequest" \
+                          -d '{"user":"admin","password":"'"${ARTIFACTORY_PASSWORD}"'","type":"login"}' | grep FALSE)
+          - export REFRESHTOKEN=$(echo $COOKIES | grep REFRESHTOKEN | awk '{print $7}')
+          - export ACCESSTOKEN=$(echo $COOKIES | grep ACCESSTOKEN | awk '{print $14}') # awk returns null on Mac, and the actual key on Ubuntu
+          - >-
+            export ACCESS_KEY=$(curl -g --request GET "${JFROG_URL}/ui/api/v1/system/security/token?services[]=all" \
+                                --header "accept: application/json, text/plain, */*" \
+                                --header "x-requested-with: XMLHttpRequest" \
+                                --header "cookie: ACCESSTOKEN=${ACCESSTOKEN}; REFRESHTOKEN=${REFRESHTOKEN}")
+          - add_run_variables JFROG_ACCESS_TOKEN=${ACCESS_KEY}
+          - echo "Unset ARTIFACTORY_PASSWORD, acceptance test will use JFROG_ACCESS_TOKEN instead"
+          - unset ARTIFACTORY_PASSWORD
+          - TF_ACC=true make acceptance
+          - make install
+        onSuccess:
+          - echo "Success"
+          - send_notification partnership_slack --text "${pipeline_name} step <${step_url}|${step_name}> is completed. Version ${PROVIDER_VERSION:-" wasn't set"}."
+        onFailure:
+          - echo "Failure, sending status to GitHub and Slack."
+          - export STATE="failure"
+          - export DESCRIPTION="Pipeline has failed."
+          - git clone https://${int_partnership_github_token}@github.com/jfrog/terraform-provider-shared.git
+          - ./terraform-provider-shared/scripts/github-status.sh ${res_terraform_provider_platform_gitProvider_token} ${res_terraform_provider_platform_gitRepoFullName} ${res_terraform_provider_platform_commitSha}
+          - send_notification partnership_slack --text "${pipeline_name} pipeline failed on <${step_url}|${step_name}> step"
+        onComplete:
+          - echo "Complete"
+
+    - name: pr_info_add_rt_version
+      type: Bash
+      configuration:
+        priority: 1
+        integrations:
+          - name: partnership_slack
+          - name: partnership_github
+        inputSteps:
+          - name: build_and_run_tf_provider_matrix
+        inputResources:
+          - name: terraform_provider_platform
+      execution:
+        onStart:
+          - echo "Preparing for work..."
+        onExecute:
+          - printenv
+          - export PR_URL=${res_terraform_provider_platform_commitUrl}
+          - export PR_COMMITTER=${res_terraform_provider_platform_committerLogin}
+          - export PR_BRANCH=${res_terraform_provider_platform_headCommitRef}
+          - >-
+            if [[ -z "${res_terraform_provider_platform_headCommitRef}" ]]; then
+              echo "No headCommitRef (PR branch), exit without adding changes to CHANGELOG.md"
+              exit 0
+            fi
+          - export PR_TITLE=$(echo ${res_terraform_provider_platform_commitMessage:0:100}... | sed 's/[^[:print:]\t]//g')
+          - >-
+            if [[ "${res_terraform_provider_platform_headCommitRef}" != master ]] && [[ "${res_terraform_provider_platform_headCommitRef}" != main ]]; then
+              echo "The pipeline was triggered by the PR, add Artifactory version to CHANGELOG.md and send the PR data to slack channel."
+              cd ${res_terraform_provider_platform_resourcePath}
+              echo "Checking out the branch ${res_terraform_provider_platform_headCommitRef} where the PR was created from."
+              git checkout -b ${res_terraform_provider_platform_headCommitRef}
+              sed -i -E "0,/(##\s.+\..+\..+\s\(.+\)).*/ s/(##\s.+\..+\..+\s\(.+\)).*/\1. Tested on Artifactory ${ARTIFACTORY_VERSION} with Terraform CLI ${TERRAFORM_VERSION}/" CHANGELOG.md
+              head -10 CHANGELOG.md
+              git add CHANGELOG.md
+              export REGEX="Changes to be committed*"
+              export GIT_STATUS=$(git status)
+              if [[ ${GIT_STATUS} =~ ${REGEX} ]]; then
+                echo "Adding Artifactory version to CHANGELOG.md"
+                git config --global user.name 'JFrog CI'
+                git config --global user.email 'jfrog-solutions-ci+1@jfrog.com'
+                git config --get user.name
+                git config --get user.email
+                git commit --author="JFrog CI <jfrog-solutions-ci+1@jfrog.com>" -m "JFrog Pipelines - Add Artifactory version to CHANGELOG.md"
+                git push https://${res_terraform_provider_platform_gitProvider_token}${TFProviderRepo}
+              else
+                echo "There is nothing to commit: Artifactory version hadn't changed."
+              fi
+            fi
+        onSuccess:
+          - echo "Success"
+          - >-
+            if [[ ! -z ${res_terraform_provider_platform_headCommitRef} ]]; then
+              export STATE="success"
+              export DESCRIPTION="All tests passed successfully."
+              git clone https://${int_partnership_github_token}@github.com/jfrog/terraform-provider-shared.git
+              ./terraform-provider-shared/scripts/github-status.sh ${res_terraform_provider_platform_gitProvider_token} ${res_terraform_provider_platform_gitRepoFullName} ${res_terraform_provider_platform_commitSha}
+              send_notification partnership_slack --text "<${res_terraform_provider_platform_gitRepoRepositoryHttpsUrl}|Terraform Provider>. A new PR was submitted by *${PR_COMMITTER}* - <${PR_URL}|${PR_TITLE}>, branch *${PR_BRANCH}*. Changes tested successfully. <@U01H1SLSPA8> or <@UNDRUL1EU> please, review and merge."
+            fi
+        onFailure:
+          - echo "Failure, sending status to GitHub and Slack."
+          - export STATE="failure"
+          - export DESCRIPTION="Pipeline has failed."
+          - git clone https://${int_partnership_github_token}@github.com/jfrog/terraform-provider-shared.git
+          - ./terraform-provider-shared/scripts/github-status.sh ${res_terraform_provider_platform_gitProvider_token} ${res_terraform_provider_platform_gitRepoFullName} ${res_terraform_provider_platform_commitSha}
+          - >-
+            if [[ "${PR_URL}" == null ]]; then
+              send_notification partnership_slack --text "${pipeline_name} step ${step_name} is failed. PR was not created (already exists from this head branch?)"
+            else
+              send_notification partnership_slack --text "${pipeline_name} failed on <${step_url}|${step_name}> step."
+            fi
+        onComplete:
+          - echo "Cleaning up"

--- a/scripts/run-artifactory.sh
+++ b/scripts/run-artifactory.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+set -euf
+
+docker run -i -t -d --rm -v "${SCRIPT_DIR}/artifactory.lic:/artifactory_extra_conf/artifactory.lic:ro" \
+  -p8081:8081 -p8082:8082 -p8080:8080 releases-docker.jfrog.io/jfrog/artifactory-pro:7.27.10
+
+echo "Waiting for Artifactory to start"
+until curl -sf -u admin:password http://localhost:8081/artifactory/api/system/licenses/; do
+    printf '.'
+    sleep 4
+done
+echo ""
+# Use decrypted passwords
+curl -u admin:password  --output /dev/null --silent --fail localhost:8080/projects/api/system/decrypt -X POST


### PR DESCRIPTION
* Clean up sample.tf to support 'make install'

Currently acceptance test for Workers Service resource will be skipped if `JFROG_URL` is not set to an instance on the cloud (ended with `jfrog.io`). Thus the pipeline currently doesn't execute the one and only acceptance test.