### PR TITLE
Update documentation to match API's 'ANY' repo types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.5.1 (Apr 3, 2024)
+
+BUG FIXES:
+
+* resource/platform_permission: Update documentation for target `name` attribute for `ANY` repository types. Correct values should be `ANY LOCAL`, `ANY REMOTE`, or `ANY DISTRIBUTION`. Note the removal of underscore character. Issue: [#48](https://github.com/jfrog/terraform-provider-platform/issues/48) PR: [#49](https://github.com/jfrog/terraform-provider-platform/pull/49)
+
+
 ## 1.5.0 (Mar 26, 2024)
 
 FEATURES:

--- a/docs/resources/permission.md
+++ b/docs/resources/permission.md
@@ -150,7 +150,7 @@ Optional:
 
 Required:
 
-- `name` (String) Specify repository key as name. Use `ANY_LOCAL`, `ANY_REMOTE`, or `ANY_DISTRIBUTION` for any repository type.
+- `name` (String) Specify repository key as name. Use `ANY LOCAL`, `ANY REMOTE`, or `ANY DISTRIBUTION` for any repository type.
 
 Optional:
 

--- a/pkg/platform/resource_permission.go
+++ b/pkg/platform/resource_permission.go
@@ -157,7 +157,7 @@ func (r *permissionResource) Schema(ctx context.Context, req resource.SchemaRequ
 					),
 					"targets": targetAttributeSchema(
 						false,
-						"Specify repository key as name. Use `ANY_LOCAL`, `ANY_REMOTE`, or `ANY_DISTRIBUTION` for any repository type.",
+						"Specify repository key as name. Use `ANY LOCAL`, `ANY REMOTE`, or `ANY DISTRIBUTION` for any repository type.",
 						"Simple comma separated wildcard patterns for **existing and future** repository artifact paths (with no leading slash). Ant-style path expressions are supported (*, **, ?). For example: `org/apache/**`",
 						"Simple comma separated wildcard patterns for **existing and future** repository artifact paths (with no leading slash). Ant-style path expressions are supported (*, **, ?). For example: `org/apache/**`",
 					),
@@ -539,6 +539,7 @@ func (r *permissionResourceModel) fromResourceAPIModel(ctx context.Context, reso
 					excludePatterns = s
 
 				}
+
 				t, d := types.ObjectValue(
 					targetResourceModelAttributeType,
 					map[string]attr.Value{

--- a/pkg/platform/resource_permission_test.go
+++ b/pkg/platform/resource_permission_test.go
@@ -96,15 +96,15 @@ func TestAccPermission_full(t *testing.T) {
 					exclude_patterns = ["{{ .excludePattern }}"]
 				},
 				{
-					name = "ALL-LOCAL"
+					name = "ANY LOCAL"
 					include_patterns = ["**", "*.js"]
 				},
 				{
-					name = "ALL-REMOTE"
+					name = "ANY REMOTE"
 					include_patterns = ["**", "*.js"]
 				},
 				{
-					name = "ALL-DISTRIBUTION"
+					name = "ANY DISTRIBUTION"
 					include_patterns = ["**", "*.js"]
 				}
 			]


### PR DESCRIPTION
Close #48 

Update documentation for target `name` attribute for `ANY` repository types. Correct values should be `ANY LOCAL`, `ANY REMOTE`, or `ANY DISTRIBUTION`. Note the removal of underscore character.