### PR TITLE
Remove trailing slash from GitHub OIDC provider URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.3 (May 6, 2024)
+
+BUG FIXES:
+
+* resource/platform_oidc_configuration: Remove trailing slash from GitHub provider URL validation. Issue: [#71](https://github.com/jfrog/terraform-provider-platform/issues/71) PR: [#72](https://github.com/jfrog/terraform-provider-platform/pull/72)
+
 ## 1.7.2 (May 1, 2024)
 
 BUG FIXES:

--- a/docs/resources/oidc_configuration.md
+++ b/docs/resources/oidc_configuration.md
@@ -35,7 +35,7 @@ resource "platform_oidc_configuration" "my-generic-oidc-configuration" {
 
 ### Required
 
-- `issuer_url` (String) OIDC issuer URL. For GitHub actions, the URL must be https://token.actions.githubusercontent.com/.
+- `issuer_url` (String) OIDC issuer URL. For GitHub actions, the URL must be https://token.actions.githubusercontent.com.
 - `name` (String) Name of the OIDC provider
 - `provider_type` (String) Type of OIDC provider. Can be `generic` or `GitHub`.
 

--- a/pkg/platform/resource_oidc_configuration.go
+++ b/pkg/platform/resource_oidc_configuration.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	gitHubProviderType        = "GitHub"
-	gitHubProviderURL         = "https://token.actions.githubusercontent.com/"
+	gitHubProviderURL         = "https://token.actions.githubusercontent.com"
 	odicConfigurationEndpoint = "/access/api/v1/oidc"
 )
 

--- a/pkg/platform/resource_oidc_configuration_test.go
+++ b/pkg/platform/resource_oidc_configuration_test.go
@@ -174,7 +174,7 @@ func TestAccOIDCConfiguration_invalid_provider_type_issuer_url(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      config,
-				ExpectError: regexp.MustCompile(`must be set to https:\/\/token\.actions\.githubusercontent\.com\/`),
+				ExpectError: regexp.MustCompile(`must be set to https:\/\/token\.actions\.githubusercontent\.com[^\/]`),
 			},
 		},
 	})

--- a/pkg/platform/resource_oidc_configuration_test.go
+++ b/pkg/platform/resource_oidc_configuration_test.go
@@ -37,7 +37,7 @@ func TestAccOIDCConfiguration_full(t *testing.T) {
 
 	updatedTestData := map[string]string{
 		"name":         configName,
-		"issuerURL":    "https://token.actions.githubusercontent.com/",
+		"issuerURL":    "https://token.actions.githubusercontent.com",
 		"providerType": "GitHub",
 		"audience":     "test-audience-2",
 	}


### PR DESCRIPTION
Close #71 