### PR TITLE
Check for null resource or attributes in state upgrader func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.4 (May 8, 2024)
+
+BUG FIXES:
+
+* resource/platform_permission: Fix state upgrader crash when upgrading from 1.7.2 to 1.7.3 with no `groups` or `users` attribute set. Issue: [#75](https://github.com/jfrog/terraform-provider-platform/issues/75) PR: [#76](https://github.com/jfrog/terraform-provider-platform/pull/76)
+
 ## 1.7.3 (May 7, 2024)
 
 BUG FIXES:

--- a/pkg/platform/resource_permission_test.go
+++ b/pkg/platform/resource_permission_test.go
@@ -521,6 +521,79 @@ func TestAccPermission_empty_users_state_migration(t *testing.T) {
 	})
 }
 
+func TestAccPermission_no_users_state_migration(t *testing.T) {
+	_, fqrn, permissionName := testutil.MkNames("test-permission", "platform_permission")
+	_, _, groupName := testutil.MkNames("test-group", "artifactory_group")
+
+	temp := `
+	resource "artifactory_group" "{{ .groupName }}" {
+		name = "{{ .groupName }}"
+	}
+
+	resource "platform_permission" "{{ .name }}" {
+		name = "{{ .name }}"
+
+		artifact = {
+			actions = {
+				groups = [
+					{
+						name = artifactory_group.{{ .groupName }}.name
+						permissions = ["READ"]
+					}
+				]
+			}
+
+			targets = []
+		}
+	}`
+
+	testData := map[string]string{
+		"name":      permissionName,
+		"groupName": groupName,
+	}
+
+	config := testutil.ExecuteTemplate(permissionName, temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckPermissionDestroy(fqrn),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"artifactory": {
+						Source: "jfrog/artifactory",
+					},
+					"platform": {
+						Source:            "jfrog/platform",
+						VersionConstraint: "1.7.2",
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "name", testData["name"]),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.users.#", "0"),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.groups.#", "1"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:                   config,
+				ProtoV6ProviderFactories: testAccProviders(),
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"artifactory": {
+						Source: "jfrog/artifactory",
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "name", testData["name"]),
+					resource.TestCheckNoResourceAttr(fqrn, "artifact.actions.users"),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.groups.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPermission_empty_groups_state_migration(t *testing.T) {
 	_, fqrn, permissionName := testutil.MkNames("test-permission", "platform_permission")
 	_, _, userName := testutil.MkNames("test-user", "artifactory_managed_user")
@@ -740,6 +813,81 @@ func TestAccPermission_empty_groups_state_migration(t *testing.T) {
 					resource.TestCheckNoResourceAttr(fqrn, "destination.actions.groups"),
 					resource.TestCheckResourceAttr(fqrn, "pipeline_source.actions.users.#", "1"),
 					resource.TestCheckNoResourceAttr(fqrn, "pipeline_source.actions.groups"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPermission_no_groups_state_migration(t *testing.T) {
+	_, fqrn, permissionName := testutil.MkNames("test-permission", "platform_permission")
+	_, _, userName := testutil.MkNames("test-user", "artifactory_managed_user")
+
+	temp := `
+	resource "artifactory_managed_user" "{{ .userName }}" {
+		name = "{{ .userName }}"
+		email = "{{ .userName }}@tempurl.org"
+		password = "Password!123"
+	}
+
+	resource "platform_permission" "{{ .name }}" {
+		name = "{{ .name }}"
+
+		artifact = {
+			actions = {
+				users = [
+					{
+						name = artifactory_managed_user.{{ .userName }}.name
+						permissions = ["READ"]
+					}
+				]
+			}
+
+			targets = []
+		}
+	}`
+
+	testData := map[string]string{
+		"name":     permissionName,
+		"userName": userName,
+	}
+
+	config := testutil.ExecuteTemplate(permissionName, temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckPermissionDestroy(fqrn),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"artifactory": {
+						Source: "jfrog/artifactory",
+					},
+					"platform": {
+						Source:            "jfrog/platform",
+						VersionConstraint: "1.7.2",
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "name", testData["name"]),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.users.#", "1"),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.groups.#", "0"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:                   config,
+				ProtoV6ProviderFactories: testAccProviders(),
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"artifactory": {
+						Source: "jfrog/artifactory",
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "name", testData["name"]),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.users.#", "1"),
+					resource.TestCheckNoResourceAttr(fqrn, "artifact.actions.groups"),
 				),
 			},
 		},


### PR DESCRIPTION
Also use path.MatchRoot().AtName() to find the correct path expression for setting attribute value.

Fixes #75 