### PR TITLE
Set saml_settings 'certificate' attribute as sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.13.1 (October 8, 2024)
+
+BUG FIXES:
+
+* resource/platform_saml_settings: Fix `certificate` attribute not being set as 'sensitive' so its value is redacted in CLI output/log. Issue: [#135](https://github.com/jfrog/terraform-provider-platform/issues/135) PR: [#136](https://github.com/jfrog/terraform-provider-platform/pull/136)
+
 ## 1.13.0 (October 4, 2024). Tested on Artifactory 7.90.13 with Terraform 1.9.7 and OpenTofu 1.8.3
 
 NOTES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.13.1 (October 8, 2024)
+## 1.13.1 (October 8, 2024). Tested on Artifactory 7.90.13 with Terraform 1.9.7 and OpenTofu 1.8.3
 
 BUG FIXES:
 

--- a/pkg/platform/resource_saml_settings.go
+++ b/pkg/platform/resource_saml_settings.go
@@ -160,7 +160,8 @@ var samlSettingsSchemaV0 = map[string]schema.Attribute{
 		MarkdownDescription: "When set, SAML integration is enabled and users may be authenticated via a SAML server. Default value is `true`.",
 	},
 	"certificate": schema.StringAttribute{
-		Required: true,
+		Required:  true,
+		Sensitive: true,
 		Validators: []validator.String{
 			stringvalidator.LengthAtLeast(1),
 		},


### PR DESCRIPTION
Fix #135 