### PR TITLE
Add 'project_key' to OIDC config and identity mapping resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.14.0 (October 12, 2024)
+
+IMPROVEMENTS:
+
+* resource/platform_oidc_configuration: Add `project_key` attribute to support project scope OIDC configuration.
+* resource/platform_oidc_identity_mapping: Add `project_key` attribute to support project scope OIDC identity mapping.
+* resource/platform_oidc_identity_mapping: Add support for `applied-permissions/roles` to `scope` attribute to support project role scope.
+
+PR: [#137](https://github.com/jfrog/terraform-provider-platform/pull/137) and [#138](https://github.com/jfrog/terraform-provider-platform/pull/138)
+
 ## 1.13.1 (October 8, 2024). Tested on Artifactory 7.90.13 with Terraform 1.9.7 and OpenTofu 1.8.3
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.14.0 (October 12, 2024)
+## 1.14.0 (October 12, 2024). Tested on Artifactory 7.90.14 with Terraform 1.9.7 and OpenTofu 1.8.3
 
 IMPROVEMENTS:
 

--- a/docs/resources/oidc_configuration.md
+++ b/docs/resources/oidc_configuration.md
@@ -43,6 +43,7 @@ resource "platform_oidc_configuration" "my-generic-oidc-configuration" {
 
 - `audience` (String) Informational field that you can use to include details of the audience that uses the OIDC configuration.
 - `description` (String) Description of the OIDC provider
+- `project_key` (String) If set, this Identity Configuration will be available in the scope of the given project (editable by platform admin and project admin). If not set, this Identity Configuration will be global and only editable by platform admin. Once set, the projectKey cannot be changed.
 
 ## Import
 
@@ -50,4 +51,6 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import platform_oidc_configuration.my-oidc-configuration my-oidc-configuration
+
+terraform import platform_oidc_configuration.my-oidc-configuration my-oidc-configuration:myproj
 ```

--- a/docs/resources/oidc_identity_mapping.md
+++ b/docs/resources/oidc_identity_mapping.md
@@ -72,13 +72,13 @@ resource "platform_oidc_identity_mapping" "my-github-oidc-group-identity-mapping
 
 Required:
 
-- `scope` (String) Scope of the token. Must start with `applied-permissions/user`, `applied-permissions/admin`, `applied-permissions/roles:`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\"readers\",\"my-group\",` Role permissions must be comma-separated, double quotes wrapped, e.g. `applied-permissions:roles:"Developer","Viewer"
+- `scope` (String) Scope of the token. Must start with `applied-permissions/user`, `applied-permissions/admin`, `applied-permissions/roles:`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\"readers\",\"my-group\",` Role permissions must be comma-separated, double quotes wrapped, e.g. `applied-permissions:roles:"Developer","Viewer". `username` is also required when setting role permission.
 
 Optional:
 
 - `audience` (String) Sets of (space separated) the JFrog services to which the mapping applies. Default value is `*@*`, which applies to all services.
 - `expires_in` (Number) Token expiry time in seconds. Default value is 60.
-- `username` (String) User name of the OIDC user. Not applicable when `scope` is set to `applied-permissions/groups`
+- `username` (String) User name of the OIDC user. Not applicable when `scope` is set to `applied-permissions/groups`. Must be set when `scope` is set to `applied-permissions/roles`.
 
 ## Import
 

--- a/docs/resources/oidc_identity_mapping.md
+++ b/docs/resources/oidc_identity_mapping.md
@@ -65,13 +65,14 @@ resource "platform_oidc_identity_mapping" "my-github-oidc-group-identity-mapping
 ### Optional
 
 - `description` (String) Description of the OIDC mapping
+- `project_key` (String) If set, this Identity Mapping will be available in the scope of the given project (editable by platform admin and project admin). If not set, this Identity Mapping will be global and only editable by platform admin. Once set, the projectKey cannot be changed.
 
 <a id="nestedatt--token_spec"></a>
 ### Nested Schema for `token_spec`
 
 Required:
 
-- `scope` (String) Scope of the token. Must start with `applied-permissions/user`, `applied-permissions/admin`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\"readers\",\"my-group\",`
+- `scope` (String) Scope of the token. Must start with `applied-permissions/user`, `applied-permissions/admin`, `applied-permissions/roles:`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\"readers\",\"my-group\",` Role permissions must be comma-separated, double quotes wrapped, e.g. `applied-permissions:roles:"Developer","Viewer"
 
 Optional:
 
@@ -85,4 +86,6 @@ Import is supported using the following syntax:
 
 ```shell
 terraform import platform_oidc_identity_mapping.my-oidc-identity-mapping my-oidc-identity-mapping:my-oidc-configuration
+
+terraform import platform_oidc_identity_mapping.my-oidc-identity-mapping my-oidc-identity-mapping:my-oidc-configuration:myproj
 ```

--- a/docs/resources/saml_settings.md
+++ b/docs/resources/saml_settings.md
@@ -40,7 +40,7 @@ resource "platform_saml_settings" "my-okta-saml-settings" {
 
 ### Required
 
-- `certificate` (String) The certificate for SAML Authentication in Base64 format. NOTE! The certificate must contain the public key to allow Artifactory to verify sign-in requests.
+- `certificate` (String, Sensitive) The certificate for SAML Authentication in Base64 format. NOTE! The certificate must contain the public key to allow Artifactory to verify sign-in requests.
 - `login_url` (String) The identity provider login URL (when you try to login, the service provider redirects to this URL).
 - `logout_url` (String) The identity provider logout URL (when you try to logout, the service provider redirects to this URL).
 - `name` (String) SAML Settings name.

--- a/examples/resources/platform_oidc_configuration/import.sh
+++ b/examples/resources/platform_oidc_configuration/import.sh
@@ -1,1 +1,3 @@
 terraform import platform_oidc_configuration.my-oidc-configuration my-oidc-configuration
+
+terraform import platform_oidc_configuration.my-oidc-configuration my-oidc-configuration:myproj

--- a/examples/resources/platform_oidc_identity_mapping/import.sh
+++ b/examples/resources/platform_oidc_identity_mapping/import.sh
@@ -1,1 +1,3 @@
 terraform import platform_oidc_identity_mapping.my-oidc-identity-mapping my-oidc-identity-mapping:my-oidc-configuration
+
+terraform import platform_oidc_identity_mapping.my-oidc-identity-mapping my-oidc-identity-mapping:my-oidc-configuration:myproj

--- a/pkg/platform/resource_oidc_identity_mapping.go
+++ b/pkg/platform/resource_oidc_identity_mapping.go
@@ -92,7 +92,7 @@ func (r *odicIdentityMappingResource) Schema(ctx context.Context, req resource.S
 						Validators: []validator.String{
 							stringvalidator.LengthAtLeast(1),
 						},
-						Description: "User name of the OIDC user. Not applicable when `scope` is set to `applied-permissions/groups`",
+						Description: "User name of the OIDC user. Not applicable when `scope` is set to `applied-permissions/groups`. Must be set when `scope` is set to `applied-permissions/roles`.",
 					},
 					"scope": schema.StringAttribute{
 						Required: true,
@@ -102,7 +102,7 @@ func (r *odicIdentityMappingResource) Schema(ctx context.Context, req resource.S
 								"must start with either 'applied-permissions/admin', 'applied-permissions/user', 'applied-permissions/groups:', or 'applied-permissions/roles:'",
 							),
 						},
-						MarkdownDescription: "Scope of the token. Must start with `applied-permissions/user`, `applied-permissions/admin`, `applied-permissions/roles:`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\\\"readers\\\",\\\"my-group\\\",` Role permissions must be comma-separated, double quotes wrapped, e.g. `applied-permissions:roles:\"Developer\",\"Viewer\"",
+						MarkdownDescription: "Scope of the token. Must start with `applied-permissions/user`, `applied-permissions/admin`, `applied-permissions/roles:`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\\\"readers\\\",\\\"my-group\\\",` Role permissions must be comma-separated, double quotes wrapped, e.g. `applied-permissions:roles:\"Developer\",\"Viewer\". `username` is also required when setting role permission.",
 					},
 					"audience": schema.StringAttribute{
 						Optional: true,


### PR DESCRIPTION
Also finish up adding `applied-permissions/roles` support to `scope` attribute for OIDC identity mapping from #137 
