### PR TITLE
Remove validation for 'users' and 'groups' to allow empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.15.1 (October 18, 2024)
+## 1.15.1 (October 18, 2024). Tested on Artifactory 7.90.14 with Terraform 1.9.8 and OpenTofu 1.8.3
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.15.1 (October 18, 2024)
+
+IMPROVEMENTS:
+
+* resource/artifactory_local_repository_multi_replication: Update validation for `actions.users` and `actions.groups` attributes to allow empty list. Issue: [#142](https://github.com/jfrog/terraform-provider-platform/issues/142) PR: [#143](https://github.com/jfrog/terraform-provider-platform/pull/143)
+
 ## 1.15.0 (October 16, 2024). Tested on Artifactory 7.90.14 with Terraform 1.9.7 and OpenTofu 1.8.3
 
 IMPROVEMENTS:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -59,7 +59,7 @@ update_pkg_cache:
 	GOPROXY=https://proxy.golang.org GO111MODULE=on go get github.com/jfrog/terraform-provider-${PRODUCT}@v${VERSION}
 
 build: fmt
-	GORELEASER_CURRENT_TAG=${NEXT_VERSION} goreleaser build --clean --snapshot # --single-target
+	GORELEASER_CURRENT_TAG=${NEXT_VERSION} goreleaser build --clean --snapshot --single-target
 
 test:
 	@echo "==> Starting unit tests"

--- a/pkg/platform/resource_permission_test.go
+++ b/pkg/platform/resource_permission_test.go
@@ -91,6 +91,8 @@ func TestAccPermission_full(t *testing.T) {
 						permissions = ["READ", "WRITE"]
 					}
 				]
+
+				groups = []
 			}
 
 			targets = [
@@ -115,6 +117,11 @@ func TestAccPermission_full(t *testing.T) {
 		}
 
 		build = {
+			actions = {
+				users = []
+				groups = []
+			}
+
 			targets = [
 				{
 					name = "artifactory-build-info"
@@ -245,9 +252,9 @@ func TestAccPermission_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "artifact.actions.users.0.permissions.#", "2"),
 					resource.TestCheckTypeSetElemAttr(fqrn, "artifact.actions.users.0.permissions.*", "READ"),
 					resource.TestCheckTypeSetElemAttr(fqrn, "artifact.actions.users.0.permissions.*", "WRITE"),
-					resource.TestCheckNoResourceAttr(fqrn, "artifact.actions.groups"),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.groups.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "artifact.targets.#", "4"),
-					resource.TestCheckNoResourceAttr(fqrn, "build.actions"),
+					resource.TestCheckResourceAttr(fqrn, "build.actions.users.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "build.targets.#", "1"),
 					resource.TestCheckResourceAttr(fqrn, "build.targets.0.name", "artifactory-build-info"),
 					resource.TestCheckResourceAttr(fqrn, "build.targets.0.include_patterns.#", "1"),
@@ -506,15 +513,15 @@ func TestAccPermission_empty_users_state_migration(t *testing.T) {
 				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "name", testData["name"]),
-					resource.TestCheckNoResourceAttr(fqrn, "artifact.actions.users"),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.users.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "artifact.actions.groups.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "build.actions.users"),
+					resource.TestCheckResourceAttr(fqrn, "build.actions.users.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "build.actions.groups.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "release_bundle.actions.users"),
+					resource.TestCheckResourceAttr(fqrn, "release_bundle.actions.users.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "release_bundle.actions.groups.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "destination.actions.users"),
+					resource.TestCheckResourceAttr(fqrn, "destination.actions.users.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "destination.actions.groups.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "pipeline_source.actions.users"),
+					resource.TestCheckResourceAttr(fqrn, "pipeline_source.actions.users.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "pipeline_source.actions.groups.#", "1"),
 				),
 			},
@@ -587,7 +594,7 @@ func TestAccPermission_no_users_state_migration(t *testing.T) {
 				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "name", testData["name"]),
-					resource.TestCheckNoResourceAttr(fqrn, "artifact.actions.users"),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.users.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "artifact.actions.groups.#", "1"),
 				),
 			},
@@ -805,15 +812,15 @@ func TestAccPermission_empty_groups_state_migration(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "name", testData["name"]),
 					resource.TestCheckResourceAttr(fqrn, "artifact.actions.users.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "artifact.actions.groups"),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.groups.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "build.actions.users.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "build.actions.groups"),
+					resource.TestCheckResourceAttr(fqrn, "build.actions.groups.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "release_bundle.actions.users.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "release_bundle.actions.groups"),
+					resource.TestCheckResourceAttr(fqrn, "release_bundle.actions.groups.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "destination.actions.users.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "destination.actions.groups"),
+					resource.TestCheckResourceAttr(fqrn, "destination.actions.groups.#", "0"),
 					resource.TestCheckResourceAttr(fqrn, "pipeline_source.actions.users.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "pipeline_source.actions.groups"),
+					resource.TestCheckResourceAttr(fqrn, "pipeline_source.actions.groups.#", "0"),
 				),
 			},
 		},
@@ -888,7 +895,7 @@ func TestAccPermission_no_groups_state_migration(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "name", testData["name"]),
 					resource.TestCheckResourceAttr(fqrn, "artifact.actions.users.#", "1"),
-					resource.TestCheckNoResourceAttr(fqrn, "artifact.actions.groups"),
+					resource.TestCheckResourceAttr(fqrn, "artifact.actions.groups.#", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
Set default value with empty list for the same

Fix makefile

Fix #142 