### PR TITLE
fix(oidc): add GitHub actions `issuer` customization for enterprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.18.1 (November 26, 2024).
+
+BUG FIXES:
+
+* resource/platform_oidc_configuration: Add GitHub actions `issuer` customization for enterprise. See [Customizing the issuer value for an enterprise](https://docs.github.com/en/enterprise-cloud@latest/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise).
+
 ## 1.18.0 (November 21, 2024). Tested on Artifactory 7.98.8 with Terraform 1.9.8 and OpenTofu 1.8.5
 
 IMPROVEMENTS:

--- a/docs/resources/oidc_configuration.md
+++ b/docs/resources/oidc_configuration.md
@@ -21,6 +21,14 @@ resource "platform_oidc_configuration" "my-github-oidc-configuration" {
   audience      = "jfrog-github"
 }
 
+resource "platform_oidc_configuration" "my-github-oidc-enterprise-configuration" {
+  name          = "my-github-oidc-enterprise-configuration"
+  description   = "My GitHub OIDC enterprise configuration"
+  issuer_url    = "https://token.actions.githubusercontent.com/jfrog"
+  provider_type = "GitHub"
+  audience      = "jfrog-github"
+}
+
 resource "platform_oidc_configuration" "my-generic-oidc-configuration" {
   name          = "my-generic-oidc-configuration"
   description   = "My generic OIDC configuration"
@@ -35,7 +43,7 @@ resource "platform_oidc_configuration" "my-generic-oidc-configuration" {
 
 ### Required
 
-- `issuer_url` (String) OIDC issuer URL. For GitHub actions, the URL must be https://token.actions.githubusercontent.com.
+- `issuer_url` (String) OIDC issuer URL. For GitHub actions, the URL must start with https://token.actions.githubusercontent.com.
 - `name` (String) Name of the OIDC provider
 - `provider_type` (String) Type of OIDC provider. Can be `generic`, `GitHub`, or `Azure`.
 

--- a/examples/resources/platform_oidc_configuration/resource.tf
+++ b/examples/resources/platform_oidc_configuration/resource.tf
@@ -6,6 +6,14 @@ resource "platform_oidc_configuration" "my-github-oidc-configuration" {
   audience      = "jfrog-github"
 }
 
+resource "platform_oidc_configuration" "my-github-oidc-enterprise-configuration" {
+  name          = "my-github-oidc-enterprise-configuration"
+  description   = "My GitHub OIDC enterprise configuration"
+  issuer_url    = "https://token.actions.githubusercontent.com/jfrog"
+  provider_type = "GitHub"
+  audience      = "jfrog-github"
+}
+
 resource "platform_oidc_configuration" "my-generic-oidc-configuration" {
   name          = "my-generic-oidc-configuration"
   description   = "My generic OIDC configuration"

--- a/pkg/platform/resource_oidc_configuration.go
+++ b/pkg/platform/resource_oidc_configuration.go
@@ -74,7 +74,7 @@ func (r *odicConfigurationResource) Schema(ctx context.Context, req resource.Sch
 						"must use https protocol.",
 					),
 				},
-				Description: fmt.Sprintf("OIDC issuer URL. For GitHub actions, the URL must be %s.", gitHubProviderURL),
+				Description: fmt.Sprintf("OIDC issuer URL. For GitHub actions, the URL must start with %s.", gitHubProviderURL),
 			},
 			"provider_type": schema.StringAttribute{
 				Required: true,
@@ -113,11 +113,11 @@ func (r odicConfigurationResource) ValidateConfig(ctx context.Context, req resou
 		return
 	}
 
-	if data.ProviderType.ValueString() == gitHubProviderType && data.IssuerURL.ValueString() != gitHubProviderURL {
+	if data.ProviderType.ValueString() == gitHubProviderType && strings.HasPrefix(data.IssuerURL.ValueString(), gitHubProviderURL) {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("issuer_url"),
 			"Invalid Attribute Configuration",
-			fmt.Sprintf("issuer_url must be set to %s when provider_type is set to '%s'.", gitHubProviderURL, gitHubProviderType),
+			fmt.Sprintf("issuer_url must starts with %s when provider_type is set to '%s'.", gitHubProviderURL, gitHubProviderType),
 		)
 	}
 }


### PR DESCRIPTION
Checks that the issuer properly starts with https://token.actions.githubusercontent.com instead of a strict equality.

Enterprise administrators can customize their OIDC issuer to append the enterprise slug at the end, e.g.: https://token.actions.githubusercontent.com/jfrog

For more information see: https://docs.github.com/en/enterprise-cloud@latest/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect\#customizing-the-issuer-value-for-an-enterprise

---

I could not run acceptance tests because I don't have a license