### PR TITLE
Fix unexpected new value error for platform_group resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.19.1 (December 10, 2024)
+
+BUG FIXES:
+
+* resource/platform_group: Fix "Provider produced inconsistent result after apply" error for attribute `members`. Issue: [#176](https://github.com/jfrog/terraform-provider-platform/issues/176) PR: [#177](https://github.com/jfrog/terraform-provider-platform/pull/177)
+
 ## 1.19.0 (December 3, 2024). Tested on Artifactory 7.98.9 with Terraform 1.10.0 and OpenTofu 1.8.6
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.19.1 (December 10, 2024)
+## 1.19.1 (December 10, 2024). Tested on Artifactory 7.98.10 with Terraform 1.10.1 and OpenTofu 1.8.7
 
 BUG FIXES:
 

--- a/pkg/platform/resource_group.go
+++ b/pkg/platform/resource_group.go
@@ -359,13 +359,16 @@ func (r *groupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 			return
 		}
 
-		ms, d := types.SetValueFrom(ctx, types.StringType, membersRes.Members)
-		if d != nil {
-			resp.Diagnostics.Append(d...)
-			return
-		}
+		// only update members attribute if it is set in the configuration
+		if !plan.Members.IsNull() {
+			ms, d := types.SetValueFrom(ctx, types.StringType, membersRes.Members)
+			if d != nil {
+				resp.Diagnostics.Append(d...)
+				return
+			}
 
-		plan.Members = ms
+			plan.Members = ms
+		}
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)


### PR DESCRIPTION
During update of members attribute and the value becomes empty slice.

Fixes #176 