### PR TITLE
Enhanced ARM64 Build Process with Dynamic GOARM64 Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.5 (June 16, 2025). Tested on Artifactory 7.111.8 with Terraform 1.12.0 and OpenTofu 1.9.1
+
+IMPROVEMENTS:
+
+* GNUmakefile : Enhanced ARM64 Build Process with Dynamic GOARM64 Detection. PR: [245](https://github.com/jfrog/terraform-provider-platform/pull/245)
+
 ## 2.2.4 (May 17, 2025). Tested on Artifactory 7.111.7 with Terraform 1.12.0 and OpenTofu 1.9.1
 
 IMPROVEMENTS:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,6 +10,11 @@ GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOAMD64)
 LINUX_GORELEASER_ARCH:=${LINUX_GORELEASER_ARCH}_$(shell go env GOAMD64)
 endif
 
+ifeq ($(GO_ARCH), arm64)
+GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOARM64)
+LINUX_GORELEASER_ARCH:=${LINUX_GORELEASER_ARCH}_$(shell go env GOARM64)
+endif
+
 PKG_NAME=pkg/${PRODUCT}
 # if this path ever changes, you need to also update the 'ldflags' value in .goreleaser.yml
 PKG_VERSION_PATH=github.com/jfrog/terraform-provider-${PRODUCT}/${PKG_NAME}


### PR DESCRIPTION
Problem:
Previously, building the terraform-provider-platform locally on darwin_arm64 failed due to a path regex mismatch during the make install step. The goreleaser build output was not consistently tagged with the precise ARM64 variant, leading to incorrect binary paths and subsequent mv errors.

Exact Error Encountered:
"""
❯ make install
rm -fR dist terraform.d/ .terraform terraform.tfstate* .terraform.lock.hcl
==> Fixing source code with gofmt...
go: downloading github.com/hashicorp/terraform-plugin-framework v1.14.1
GORELEASER_CURRENT_TAG=2.2.5 goreleaser build --clean --snapshot --single-target
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • couldn't find any tags before "2.2.5"
    • git state                                      commit=64edf74f1873ecf233a902db5d90ae5114072b16 branch=main current_tag=2.2.5 previous_tag=<unknown> dirty=false
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
  • partial
  • snapshotting
    • building snapshot...                           version=2.2.5-SNAPSHOT-64edf74
  • running before hooks
    • running                                        hook=go mod tidy
    • took: 13s
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • partial build                                  match=target=darwin_arm64_v8.0
    • building                                       binary=dist/terraform-provider-platform_darwin_arm64_v8.0/terraform-provider-platform_v2.2.5-SNAPSHOT-64edf74
  • writing artifacts metadata
  • you are using deprecated options, check the output above for details
  • build succeeded after 15s
  • thanks for using GoReleaser!
rm -fR .terraform.d && \
	mkdir -p terraform.d/plugins/registry.terraform.io/jfrog/platform/2.2.5/darwin_arm64 && \
	mkdir -p terraform.d/plugins/registry.terraform.io/jfrog/platform/2.2.5/linux_amd64 && \
		mv -v dist/terraform-provider-platform_darwin_arm64/terraform-provider-platform_v2.2.5* terraform.d/plugins/registry.terraform.io/jfrog/platform/2.2.5/darwin_arm64 && \
		rm -f .terraform.lock.hcl && \
		sed -i.bak '0,/version = ".*"/s//version = "2.2.5"/' sample.tf && rm sample.tf.bak && \
		terraform init
mv: rename dist/terraform-provider-platform_darwin_arm64/terraform-provider-platform_v2.2.5* to terraform.d/plugins/registry.terraform.io/jfrog/platform/2.2.5/darwin_arm64/terraform-provider-platform_v2.2.5*: No such file or directory
make: *** [install] Error 1
"""
Solution:
This PR enhances the GNUmakefile to dynamically determine the exact ARM64 variant by leveraging go env GOARM64. This ensures that goreleaser builds are accurately tagged and optimized for different ARM64 environments, resolving the path mismatch issue.
