### PR TITLE
feat: added support for `SCHEDULED_EVENT` in `platform_workers_service` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.11 (May 11, 2025). Tested on Artifactory 7.146.10 with Terraform 1.15.2 and OpenTofu 1.11.6
+
+IMPROVEMENTS:
+
+* resource/platform_workers_service: Added support for `SCHEDULED_EVENT` action type [#197](https://github.com/jfrog/terraform-provider-platform/issues/197) PR: [#281](https://github.com/jfrog/terraform-provider-platform/pull/281)
+
 ## 2.2.10 (May 6, 2026). Tested on Artifactory 7.146.10 with Terraform 1.15.2 and OpenTofu 1.11.6
 
 IMPROVEMENTS:

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -43,13 +43,13 @@ Currently, acceptance tests **require an access key**. To generate an access key
 Then, you have to set some environment variables as this is how the acceptance tests pick up their config.
 
 ```sh
-ARTIFACTORY_URL=http://localhost:8082
-ARTIFACTORY_USERNAME=admin
-ARTIFACTORY_ACCESS_TOKEN=<your_access_token>
+JFROG_URL=http://localhost:8082
+JFROG_USERNAME=admin
+JFROG_ACCESS_TOKEN=<your_access_token>
 TF_ACC=true
 ```
 
-`ARTIFACTORY_USERNAME` is not used in authentication, but used in several tests, related to replication functionality. It should be hardcoded to `admin`, because it's a default user created in the Artifactory instance from the start.
+`JFROG_USERNAME` is not used in authentication, but used in several tests, related to replication functionality. It should be hardcoded to `admin`, because it's a default user created in the Artifactory instance from the start.
 
 A crucial env var to set is `TF_ACC=true` - you can literally set `TF_ACC` to anything you want, so long as it's set. The acceptance tests use terraform testing libraries that, if this flag isn't set, will skip all tests.
 

--- a/examples/resources/platform_workers_service/resource.tf
+++ b/examples/resources/platform_workers_service/resource.tf
@@ -1,3 +1,4 @@
+# Worker triggered by BEFORE_DOWNLOAD
 resource "platform_workers_service" "my-workers-service" {
   key         = "my-workers-service"
   enabled     = true
@@ -17,6 +18,41 @@ EOT
   filter_criteria = {
     artifact_filter_criteria = {
       repo_keys = ["my-repo-key"]
+    }
+  }
+
+  secrets = [
+    {
+      key   = "my-secret-key-1"
+      value = "my-secret-value-1"
+    },
+    {
+      key   = "my-secret-key-2"
+      value = "my-secret-value-2"
+    }
+  ]
+}
+
+# Worker triggerd by schedule
+resource "platform_workers_service" "my-scheduled-workers-service" {
+  key         = "my-scheduled-workers-service"
+  enabled     = true
+  description = "My Scheduled workers service"
+  source_code = <<EOT
+export default async (context: PlatformContext, data: BeforeDownloadRequest): Promise<BeforeDownloadResponse> => {
+  console.log(await context.clients.platformHttp.get('/artifactory/api/system/ping'));
+  console.log(await axios.get('https://my.external.resource'));
+  return {
+    message: 'Request is successful',
+  }
+}
+EOT
+  action      = "SCHEDULED_EVENT"
+
+  filter_criteria = {
+    schedule = {
+      cron     = "*/2 * * * *"
+      timezone = "UTC"
     }
   }
 

--- a/pkg/platform/resource_workers_service.go
+++ b/pkg/platform/resource_workers_service.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -27,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -49,6 +51,7 @@ var validActions = []string{
 	"BEFORE_PROPERTY_DELETE",
 	"AFTER_PROPERTY_CREATE",
 	"AFTER_PROPERTY_DELETE",
+	"SCHEDULED_EVENT",
 }
 
 var _ resource.Resource = (*workersServiceResource)(nil)
@@ -98,10 +101,18 @@ func (r *workersServiceResource) Schema(ctx context.Context, req resource.Schema
 			},
 			"filter_criteria": schema.SingleNestedAttribute{
 				Required:    true,
-				Description: "Defines the repositories to be used or excluded.",
+				Description: "Defines the criteria for triggering the worker, either by specifying repositories and path patterns for artifact-based filtering or by defining a schedule using a Cron expression.",
 				Attributes: map[string]schema.Attribute{
 					"artifact_filter_criteria": schema.SingleNestedAttribute{
-						Required: true,
+						Optional: true,
+						Validators: []validator.Object{
+							objectvalidator.ExactlyOneOf(
+								// self (required workaround for now)
+								path.MatchRelative(),
+								// sibling
+								path.MatchRelative().AtParent().AtName("schedule"),
+							),
+						},
 						Attributes: map[string]schema.Attribute{
 							"repo_keys": schema.SetAttribute{
 								ElementType: types.StringType,
@@ -117,6 +128,21 @@ func (r *workersServiceResource) Schema(ctx context.Context, req resource.Schema
 								ElementType: types.StringType,
 								Optional:    true,
 								Description: "Define patterns to for all repository paths for repositories to be excluded in the repoKeys. Defines those repositories that do not trigger the worker.",
+							},
+						},
+					},
+					"schedule": schema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]schema.Attribute{
+							"cron": schema.StringAttribute{
+								Required:    true,
+								Description: "Defines the Cron expression to schedule the worker.",
+							},
+							"timezone": schema.StringAttribute{
+								Optional:    true,
+								Computed:    true,
+								Default:     stringdefault.StaticString("UTC"),
+								Description: "Define which timezone the schedule applies to if provided.",
 							},
 						},
 					},
@@ -156,12 +182,18 @@ type workersServiceResourceModel struct {
 
 type filterCriteriaResourceModel struct {
 	ArtifactFilterCriteria types.Object `tfsdk:"artifact_filter_criteria"`
+	Schedule               types.Object `tfsdk:"schedule"`
 }
 
 type artifactFilterCriteriaResourceModel struct {
 	RepoKeys        types.Set `tfsdk:"repo_keys"`
 	IncludePatterns types.Set `tfsdk:"include_patterns"`
 	ExcludePatterns types.Set `tfsdk:"exclude_patterns"`
+}
+
+type scheduleResourceModel struct {
+	Cron     types.String `tfsdk:"cron"`
+	Timezone types.String `tfsdk:"timezone"`
 }
 
 func (r *workersServiceResourceModel) toAPIModel(ctx context.Context, apiModel *WorkersServiceAPIModel, secretKeysToBeRemoved []string) (ds diag.Diagnostics) {
@@ -171,20 +203,43 @@ func (r *workersServiceResourceModel) toAPIModel(ctx context.Context, apiModel *
 		return
 	}
 
-	var artifactFilterCriteria artifactFilterCriteriaResourceModel
-	ds.Append(filterCriteria.ArtifactFilterCriteria.As(ctx, &artifactFilterCriteria, basetypes.ObjectAsOptions{})...)
-	if ds.HasError() {
-		return
+	var artifactFilterCriteriaObject *artifactFilterCriteriaAPIModel
+	if !filterCriteria.ArtifactFilterCriteria.IsNull() {
+		var artifactFilterCriteria artifactFilterCriteriaResourceModel
+		ds.Append(filterCriteria.ArtifactFilterCriteria.As(ctx, &artifactFilterCriteria, basetypes.ObjectAsOptions{})...)
+		if ds.HasError() {
+			return
+		}
+
+		var repoKeys []string
+		artifactFilterCriteria.RepoKeys.ElementsAs(ctx, &repoKeys, false)
+
+		var includePatterns []string
+		artifactFilterCriteria.IncludePatterns.ElementsAs(ctx, &includePatterns, false)
+
+		var excludePatterns []string
+		artifactFilterCriteria.ExcludePatterns.ElementsAs(ctx, &excludePatterns, false)
+
+		artifactFilterCriteriaObject = &artifactFilterCriteriaAPIModel{
+			RepoKeys:        repoKeys,
+			IncludePatterns: includePatterns,
+			ExcludePatterns: excludePatterns,
+		}
 	}
 
-	var repoKeys []string
-	artifactFilterCriteria.RepoKeys.ElementsAs(ctx, &repoKeys, false)
+	var scheduleObject *scheduleAPIModel
+	if !filterCriteria.Schedule.IsNull() && !filterCriteria.Schedule.IsUnknown() {
+		var schedule scheduleResourceModel
+		ds.Append(filterCriteria.Schedule.As(ctx, &schedule, basetypes.ObjectAsOptions{})...)
+		if ds.HasError() {
+			return
+		}
 
-	var includePatterns []string
-	artifactFilterCriteria.IncludePatterns.ElementsAs(ctx, &includePatterns, false)
-
-	var excludePatterns []string
-	artifactFilterCriteria.ExcludePatterns.ElementsAs(ctx, &excludePatterns, false)
+		scheduleObject = &scheduleAPIModel{
+			Cron:     schedule.Cron.ValueString(),
+			Timezone: schedule.Timezone.ValueString(),
+		}
+	}
 
 	secrets := lo.Map[attr.Value](
 		r.Secrets.Elements(),
@@ -213,11 +268,8 @@ func (r *workersServiceResourceModel) toAPIModel(ctx context.Context, apiModel *
 		SourceCode:  r.SourceCode.ValueString(),
 		Action:      r.Action.ValueString(),
 		FilterCriteria: filterCriteriaAPIModel{
-			ArtifactFilterCriteria: artifactFilterCriteriaAPIModel{
-				RepoKeys:        repoKeys,
-				IncludePatterns: includePatterns,
-				ExcludePatterns: excludePatterns,
-			},
+			ArtifactFilterCriteria: artifactFilterCriteriaObject,
+			Schedule:               scheduleObject,
 		},
 		Enabled: r.Enabled.ValueBool(),
 		Secrets: secrets,
@@ -230,6 +282,9 @@ var filterCriteriaResourceModelAttributeTypes map[string]attr.Type = map[string]
 	"artifact_filter_criteria": types.ObjectType{
 		AttrTypes: artifactFilterCriteriaResourceModelAttributeTypes,
 	},
+	"schedule": types.ObjectType{
+		AttrTypes: scheduleResourceModelAttributeTypes,
+	},
 }
 
 var artifactFilterCriteriaResourceModelAttributeTypes map[string]attr.Type = map[string]attr.Type{
@@ -238,68 +293,101 @@ var artifactFilterCriteriaResourceModelAttributeTypes map[string]attr.Type = map
 	"exclude_patterns": types.SetType{ElemType: types.StringType},
 }
 
+var scheduleResourceModelAttributeTypes map[string]attr.Type = map[string]attr.Type{
+	"cron":     types.StringType,
+	"timezone": types.StringType,
+}
+
 func (r *workersServiceResourceModel) fromAPIModel(ctx context.Context, apiModel *WorkersServiceAPIModel) (ds diag.Diagnostics) {
 	r.Key = types.StringValue(apiModel.Key)
 	r.Description = types.StringValue(apiModel.Description)
 	r.SourceCode = types.StringValue(apiModel.SourceCode)
 	r.Action = types.StringValue(apiModel.Action)
 
-	repoKeys, d := types.SetValueFrom(
-		ctx,
-		types.StringType,
-		apiModel.FilterCriteria.ArtifactFilterCriteria.RepoKeys,
-	)
-	if d != nil {
-		ds = append(ds, d...)
-	}
-	if ds.HasError() {
-		return
-	}
-	includePatterns, d := types.SetValueFrom(
-		ctx,
-		types.StringType,
-		apiModel.FilterCriteria.ArtifactFilterCriteria.IncludePatterns,
-	)
-	if d != nil {
-		ds = append(ds, d...)
-	}
-	if ds.HasError() {
-		return
-	}
-	excludePatterns, d := types.SetValueFrom(
-		ctx,
-		types.StringType,
-		apiModel.FilterCriteria.ArtifactFilterCriteria.ExcludePatterns,
-	)
-	if d != nil {
-		ds = append(ds, d...)
-	}
-	if ds.HasError() {
-		return
+	artifactFilterCriteriaObject := types.ObjectNull(artifactFilterCriteriaResourceModelAttributeTypes)
+	if apiModel.FilterCriteria.ArtifactFilterCriteria != nil {
+		repoKeys, d := types.SetValueFrom(
+			ctx,
+			types.StringType,
+			apiModel.FilterCriteria.ArtifactFilterCriteria.RepoKeys,
+		)
+		if d != nil {
+			ds = append(ds, d...)
+		}
+		if ds.HasError() {
+			return
+		}
+		includePatterns, d := types.SetValueFrom(
+			ctx,
+			types.StringType,
+			apiModel.FilterCriteria.ArtifactFilterCriteria.IncludePatterns,
+		)
+		if d != nil {
+			ds = append(ds, d...)
+		}
+		if ds.HasError() {
+			return
+		}
+		excludePatterns, d := types.SetValueFrom(
+			ctx,
+			types.StringType,
+			apiModel.FilterCriteria.ArtifactFilterCriteria.ExcludePatterns,
+		)
+		if d != nil {
+			ds = append(ds, d...)
+		}
+		if ds.HasError() {
+			return
+		}
+
+		artifactFilterCriteriaValue := artifactFilterCriteriaResourceModel{
+			RepoKeys:        repoKeys,
+			IncludePatterns: includePatterns,
+			ExcludePatterns: excludePatterns,
+		}
+
+		atrifactFilterCriteria, d := types.ObjectValueFrom(
+			ctx,
+			artifactFilterCriteriaResourceModelAttributeTypes,
+			artifactFilterCriteriaValue,
+		)
+		if d != nil {
+			ds = append(ds, d...)
+		}
+		if ds.HasError() {
+			return
+		}
+
+		artifactFilterCriteriaObject = atrifactFilterCriteria
 	}
 
-	artifactFilterCriteriaValue := artifactFilterCriteriaResourceModel{
-		RepoKeys:        repoKeys,
-		IncludePatterns: includePatterns,
-		ExcludePatterns: excludePatterns,
-	}
+	scheduleObject := types.ObjectNull(scheduleResourceModelAttributeTypes)
+	if apiModel.FilterCriteria.Schedule != nil {
+		scheduleValue := scheduleResourceModel{
+			Cron:     types.StringValue(apiModel.FilterCriteria.Schedule.Cron),
+			Timezone: types.StringValue(apiModel.FilterCriteria.Schedule.Timezone),
+		}
 
-	atrifactFilterCriteria, d := types.ObjectValueFrom(
-		ctx,
-		artifactFilterCriteriaResourceModelAttributeTypes,
-		artifactFilterCriteriaValue,
-	)
-	if d != nil {
-		ds = append(ds, d...)
-	}
-	if ds.HasError() {
-		return
+		schedule, d := types.ObjectValueFrom(
+			ctx,
+			scheduleResourceModelAttributeTypes,
+			scheduleValue,
+		)
+		if d != nil {
+			ds = append(ds, d...)
+		}
+		if ds.HasError() {
+			return
+		}
+
+		scheduleObject = schedule
 	}
 
 	filterCriteria, d := types.ObjectValue(
 		filterCriteriaResourceModelAttributeTypes,
 		map[string]attr.Value{
-			"artifact_filter_criteria": atrifactFilterCriteria,
+			"artifact_filter_criteria": artifactFilterCriteriaObject,
+			"schedule":                 scheduleObject,
 		},
 	)
 	if d != nil {
@@ -326,13 +414,19 @@ type WorkersServiceAPIModel struct {
 }
 
 type filterCriteriaAPIModel struct {
-	ArtifactFilterCriteria artifactFilterCriteriaAPIModel `json:"artifactFilterCriteria"`
+	ArtifactFilterCriteria *artifactFilterCriteriaAPIModel `json:"artifactFilterCriteria,omitempty"`
+	Schedule               *scheduleAPIModel               `json:"schedule,omitempty"`
 }
 
 type artifactFilterCriteriaAPIModel struct {
 	RepoKeys        []string `json:"repoKeys"`
 	IncludePatterns []string `json:"includePatterns,omitempty"`
 	ExcludePatterns []string `json:"excludePatterns,omitempty"`
+}
+
+type scheduleAPIModel struct {
+	Cron     string `json:"cron"`
+	Timezone string `json:"timezone,omitempty"`
 }
 
 type secretAPIModel struct {
@@ -398,7 +492,6 @@ func (r *workersServiceResource) Read(ctx context.Context, req resource.ReadRequ
 		SetPathParam("key", state.Key.ValueString()).
 		SetResult(&workersService).
 		Get(WorkersServiceEndpoint + "/{key}")
-
 	if err != nil {
 		utilfw.UnableToRefreshResourceError(resp, err.Error())
 		return

--- a/pkg/platform/resource_workers_service_test.go
+++ b/pkg/platform/resource_workers_service_test.go
@@ -316,7 +316,6 @@ func testAccCheckWorkersServiceDestroy(id string) func(*terraform.State) error {
 		resp, err := client.R().
 			SetResult(&workersService).
 			Get(url)
-
 		if err != nil {
 			return err
 		}
@@ -686,6 +685,97 @@ func TestAccWorkersService_AfterPropertyDelete(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "source_code", testData["sourceCode"]),
 					resource.TestCheckResourceAttr(fqrn, "filter_criteria.artifact_filter_criteria.repo_keys.#", "1"),
 					resource.TestCheckResourceAttr(fqrn, "filter_criteria.artifact_filter_criteria.repo_keys.0", testData["repoKey"]),
+					resource.TestCheckResourceAttr(fqrn, "secrets.#", "2"),
+					resource.TestCheckResourceAttr(fqrn, "secrets.0.key", testData["secretKey"]),
+					resource.TestCheckResourceAttr(fqrn, "secrets.0.value", testData["secretValue"]),
+					resource.TestCheckResourceAttr(fqrn, "secrets.1.key", testData["secretKey2"]),
+					resource.TestCheckResourceAttr(fqrn, "secrets.1.value", testData["secretValue2"]),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        workersServiceName,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+				ImportStateVerifyIgnore:              []string{"secrets"}, // `secrets.value` attribute is not being sent via API, can't be imported
+			},
+		},
+	})
+}
+
+const testSchedule = "export default async (context: PlatformContext, data: ScheduledEventRequest): Promise<ScheduledEventResponse> => { console.log(await context.clients.platformHttp.get('/artifactory/api/system/ping')); console.log(await axios.get('https://my.external.resource')); return { message: 'proceed', } }"
+
+func TestAccWorkersService_Schedule(t *testing.T) {
+	jfrogURL := os.Getenv("JFROG_URL")
+	if !strings.HasSuffix(jfrogURL, "jfrog.io") {
+		t.Skipf("JFROG_URL '%s' is not a cloud instance. Workers Service is only available on cloud.", jfrogURL)
+	}
+
+	_, fqrn, workersServiceName := testutil.MkNames("test-workers-service-", "platform_workers_service")
+
+	temp := `
+	resource "platform_workers_service" "{{ .key }}" {
+		key         = "{{ .key }}"
+		enabled     = {{ .enabled }}
+		description = "{{ .description }}"
+		source_code = "{{ .sourceCode }}"
+		action      = "{{ .action }}"
+
+		filter_criteria = {
+			schedule = {
+				cron     = "{{ .cron }}"
+				timezone = "{{ .timezone }}"
+			}
+		}
+
+		secrets = [
+			{
+				key   = "{{ .secretKey }}"
+				value = "{{ .secretValue }}"
+			},
+			{
+				key   = "{{ .secretKey2 }}"
+				value = "{{ .secretValue2 }}"
+			}
+		]
+	}`
+	testData := map[string]string{
+		"key":          workersServiceName,
+		"enabled":      "true",
+		"description":  "Description",
+		"sourceCode":   testSchedule,
+		"action":       "SCHEDULED_EVENT",
+		"cron":         "*/2 * * * *",
+		"timezone":     "UTC",
+		"secretKey":    "test-secret-key",
+		"secretValue":  "test-secret-value",
+		"secretKey2":   "test-secret-key-2",
+		"secretValue2": "test-secret-value-2",
+	}
+
+	config := util.ExecuteTemplate(workersServiceName, temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"artifactory": {
+				Source:            "registry.terraform.io/jfrog/artifactory",
+				VersionConstraint: "9.9.0",
+			},
+		},
+		CheckDestroy: testAccCheckWorkersServiceDestroy(fqrn),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", workersServiceName),
+					resource.TestCheckResourceAttr(fqrn, "enabled", testData["enabled"]),
+					resource.TestCheckResourceAttr(fqrn, "description", testData["description"]),
+					resource.TestCheckResourceAttr(fqrn, "source_code", testData["sourceCode"]),
+					resource.TestCheckResourceAttr(fqrn, "filter_criteria.schedule.cron", "*/2 * * * *"),
+					resource.TestCheckResourceAttr(fqrn, "filter_criteria.schedule.timezone", "UTC"),
 					resource.TestCheckResourceAttr(fqrn, "secrets.#", "2"),
 					resource.TestCheckResourceAttr(fqrn, "secrets.0.key", testData["secretKey"]),
 					resource.TestCheckResourceAttr(fqrn, "secrets.0.value", testData["secretValue"]),

--- a/sample.tf
+++ b/sample.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     platform = {
       source  = "jfrog/platform"
-      version = "2.2.4"
+      version = "2.2.11"
     }
   }
 }


### PR DESCRIPTION
**Summary**

This PR adds support for the `SCHEDULED_EVENT` action type to the `platform_workers_service` resource as addressed in #197. The changes include a new schedule block, API model wiring, and an acceptance test. It also updates documentation for acceptance test environment variables and extends the changelog.

---

### Changes

* **`platform_workers_service` resource**

  * Adds `"SCHEDULED_EVENT"` to the list of valid `action` values.
  * Extends `filter_criteria` with an optional `schedule` block:

    ```hcl
    filter_criteria = {
      schedule = {
        cron     = "<cron expression>"
        timezone = "<timezone>" # optional
      }
    }
    ```
  * Makes `artifact_filter_criteria` optional and adds an `ExactlyOneOf` validator so that **either** `artifact_filter_criteria` **or** `schedule` is configured (but not both).

* Adds `TestAccWorkersService_Schedule` acceptance tests

* Changes `ARTIFACTORY_*` to `JFROG_*` in [CONTRIBUTIONS.md](CONTRIBUTIONS.md)

### Notes

* The change is designed to be **backwards compatible**:

  * Existing configurations using `artifact_filter_criteria` continue to work.
  * The new `schedule` block is optional and mutually exclusive with `artifact_filter_criteria`.
