### PR TITLE
JTFPR-55 - Updated saml settings markdown file to activate saml on saas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.8 (Jan 13, 2025). Tested on Artifactory 7.133.6 with Terraform 1.14.4 and OpenTofu 1.11.4
+## 2.2.8 (Feb 11, 2026).
 
 FEATURES:
 
@@ -8,6 +8,9 @@ FEATURES:
 
 * `platform_lifecycle_stage` - Resource to manage individual lifecycle stages with their configuration and metadata. Supports global and project-scoped stages.
 
+IMPROVEMENTS:
+
+* resource/platform_saml_settings: Updated documentation to clarify that the resource supports both JFrog SaaS and Self-Hosted instances. For SaaS instances, the `enable` parameter must be activated via a manual API call after Terraform apply.
 
 ## 2.2.7 (Dec 16, 2025). Tested on Artifactory 7.125.8 with Terraform 1.14.2 and OpenTofu 1.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.8 (Feb 11, 2026).
+## 2.2.8 (Feb 11, 2026). Tested on Artifactory 7.133.8 with Terraform 1.14.4 and OpenTofu 1.11.4
 
 FEATURES:
 

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -43,7 +43,7 @@ Terraform Provider for JFrog Platform, providing resources to manage platform-le
 
 9. **platform_saml_settings**
    - Configures SAML SSO settings
-   - Self-hosted instances only
+   - This resource supports both JFrog SaaS and Self-Hosted instances. For SaaS instances, the `enable` parameter must currently be activated via a manual API call after the Terraform apply is complete.
 
 10. **platform_http_sso_settings**
     - Configures HTTP-based SSO

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,13 @@
+## Description
+JTFPR-55 - Updated SAML settings documentation to support activation on SaaS.
+
+## Changes
+- **resource/platform_saml_settings**: Documentation and schema description updated to state that the resource supports both JFrog SaaS and Self-Hosted instances. For SaaS, the `enable` parameter must be activated via a manual PATCH to the Access API after Terraform apply.
+- **docs/resources/saml_settings.md**: Replaced "Only available for self-hosted instances" with SaaS/Self-Hosted support note and added "Activate SAML on SaaS" section with curl example.
+- **templates/resources/saml_settings.md.tmpl**: Aligned template with new documentation.
+- **pkg/platform/resource_saml_settings.go**: Updated resource `MarkdownDescription` to match new docs.
+- **PROJECT_SUMMARY.md**: Updated platform_saml_settings summary from "Self-hosted instances only" to reflect SaaS support.
+
+## Testing
+- [ ] Documentation reviewed for accuracy.
+- [ ] No behavioral code changes; documentation only.

--- a/docs/resources/saml_settings.md
+++ b/docs/resources/saml_settings.md
@@ -4,14 +4,14 @@ page_title: "platform_saml_settings Resource - terraform-provider-platform"
 subcategory: "Authentication Providers Configuration"
 description: |-
   Provides a JFrog SAML SSO Settings https://jfrog.com/help/r/jfrog-platform-administration-documentation/saml-sso resource.
-  ~>Only available for self-hosted instances.
+  ~>This resource supports both JFrog SaaS and Self-Hosted instances. For SaaS instances, the `enable` parameter must currently be activated via a manual API call after the Terraform apply is complete.
 ---
 
 # platform_saml_settings (Resource)
 
 Provides a JFrog [SAML SSO Settings](https://jfrog.com/help/r/jfrog-platform-administration-documentation/saml-sso) resource.
 
-~>Only available for self-hosted instances.
+~>This resource supports both JFrog SaaS and Self-Hosted instances. For SaaS instances, the `enable` parameter must currently be activated via a manual API call after the Terraform apply is complete.
 
 ## Example Usage
 

--- a/pkg/platform/resource_saml_settings.go
+++ b/pkg/platform/resource_saml_settings.go
@@ -347,7 +347,7 @@ func (r *SAMLSettingsResource) Schema(ctx context.Context, req resource.SchemaRe
 	resp.Schema = schema.Schema{
 		Version:             2,
 		Attributes:          samlSettingsSchemaV2,
-		MarkdownDescription: "Provides a JFrog [SAML SSO Settings](https://jfrog.com/help/r/jfrog-platform-administration-documentation/saml-sso) resource.\n\n~>Only available for self-hosted instances.",
+		MarkdownDescription: "Provides a JFrog [SAML SSO Settings](https://jfrog.com/help/r/jfrog-platform-administration-documentation/saml-sso) resource.\n\n~>This resource supports both JFrog SaaS and Self-Hosted instances. For SaaS instances, the `enable` parameter must currently be activated via a manual API call after the Terraform apply is complete.",
 	}
 }
 

--- a/templates/resources/saml_settings.md.tmpl
+++ b/templates/resources/saml_settings.md.tmpl
@@ -4,14 +4,14 @@ page_title: "platform_saml_settings Resource - terraform-provider-platform"
 subcategory: "Authentication Providers Configuration"
 description: |-
   Provides a JFrog SAML SSO Settings https://jfrog.com/help/r/jfrog-platform-administration-documentation/saml-sso resource.
-  ~>Only available for self-hosted instances.
+  ~>This resource supports both JFrog SaaS and Self-Hosted instances. For SaaS instances, the `enable` parameter must currently be activated via a manual API call after the Terraform apply is complete.
 ---
 
 # platform_saml_settings (Resource)
 
 Provides a JFrog [SAML SSO Settings](https://jfrog.com/help/r/jfrog-platform-administration-documentation/saml-sso) resource.
 
-~>Only available for self-hosted instances.
+~>This resource supports both JFrog SaaS and Self-Hosted instances. For SaaS instances, the `enable` parameter must currently be activated via a manual API call after the Terraform apply is complete.
 
 ## Example Usage
 


### PR DESCRIPTION
## Description
JTFPR-55 - Updated SAML settings documentation to support activation on SaaS.

## Changes
- **resource/platform_saml_settings**: Documentation and schema description updated to state that the resource supports both JFrog SaaS and Self-Hosted instances. For SaaS, the `enable` parameter must be activated via a manual PATCH to the Access API after Terraform apply.
- **docs/resources/saml_settings.md**: Replaced "Only available for self-hosted instances" with SaaS/Self-Hosted support note and added "Activate SAML on SaaS" section with curl example.
- **templates/resources/saml_settings.md.tmpl**: Aligned template with new documentation.
- **pkg/platform/resource_saml_settings.go**: Updated resource `MarkdownDescription` to match new docs.
- **PROJECT_SUMMARY.md**: Updated platform_saml_settings summary from "Self-hosted instances only" to reflect SaaS support.

## Testing
- [ ] Documentation reviewed for accuracy.
- [ ] No behavioral code changes; documentation only.