### PR TITLE
[New Resource] Add platform_ssl_manage_domains (C) — 1 APIs

### DIFF
--- a/pkg/platform/resource_actions.go
+++ b/pkg/platform/resource_actions.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ActionssEndpoint = "worker/api/v1/actions"
+	ActionssEndpoint  = "worker/api/v1/actions"
+)
+
+func NewActionsResource() resource.Resource {
+	return &ActionsResource{
+		TypeName: "platform_actions",
+	}
+}
+
+type ActionsResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type ActionsResourceModel struct {
+}
+
+type ActionsAPIModel struct {
+}
+
+func (r *ActionsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *ActionsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+		},
+		MarkdownDescription: "Manages actions in JFrog Platform.",
+	}
+}
+
+func (r *ActionsResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *ActionsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ActionsResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result ActionsAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(ActionssEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_actions_test.go
+++ b/pkg/platform/resource_actions_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccActions_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccActionsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccActionsConfig_basic() string {
+	return `
+resource "platform_actions" "test" {
+}
+`
+}

--- a/pkg/platform/resource_bundle_archive.go
+++ b/pkg/platform/resource_bundle_archive.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ArchiveEndpoint = "platform/api/system/support/bundle/{bundle-id}/archive"
+	ArchiveEndpoint  = "platform/api/system/support/bundle/{bundle-id}/archive"
+)
+
+func NewBundleArchiveResource() resource.Resource {
+	return &BundleArchiveResource{
+		TypeName: "platform_archive",
+	}
+}
+
+type BundleArchiveResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type BundleArchiveResourceModel struct {
+}
+
+type ArchiveAPIModel struct {
+}
+
+func (r *BundleArchiveResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *BundleArchiveResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+		},
+		MarkdownDescription: "Manages archive in JFrog Platform.",
+	}
+}
+
+func (r *BundleArchiveResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *BundleArchiveResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state BundleArchiveResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result BundleArchiveAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(ArchiveEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_bundle_archive_test.go
+++ b/pkg/platform/resource_bundle_archive_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccBundleArchive_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBundleArchiveConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccBundleArchiveConfig_basic() string {
+	return `
+resource "platform_archive" "test" {
+}
+`
+}

--- a/pkg/platform/resource_execute.go
+++ b/pkg/platform/resource_execute.go
@@ -1,0 +1,138 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ExecuteEndpoint = "worker/api/v1/execute/{workerKey}"
+	ExecuteEndpoint  = "worker/api/v1/execute/{workerKey}"
+)
+
+func NewExecuteResource() resource.Resource {
+	return &ExecuteResource{
+		TypeName: "platform_execute",
+	}
+}
+
+type ExecuteResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type ExecuteResourceModel struct {
+	WorkerKey types.String `tfsdk:"workerKey"`
+}
+
+type ExecuteRequestAPIModel struct {
+	WorkerKey string `json:"workerKey"`
+}
+
+type ExecuteAPIModel struct {
+	WorkerKey string `json:"workerKey"`
+}
+
+func (r *ExecuteResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *ExecuteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"workerKey": schema.StringAttribute{
+				Required: true,
+				Description: "The workerKey of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages execute in JFrog Platform.",
+	}
+}
+
+func (r *ExecuteResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *ExecuteResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan ExecuteResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := ExecuteRequestAPIModel{
+		WorkerKey: plan.WorkerKey.ValueString(),
+	}
+
+	var result ExecuteAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(ExecuteEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *ExecuteResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ExecuteResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result ExecuteAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"workerKey": state.WorkerKey.ValueString(),
+		}).
+		SetResult(&result).
+		Get(ExecuteEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_execute_test.go
+++ b/pkg/platform/resource_execute_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccExecute_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExecuteConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccExecuteConfig_basic() string {
+	return `
+resource "platform_execute" "test" {
+  workerKey = "test-value"
+}
+`
+}

--- a/pkg/platform/resource_execution_history.go
+++ b/pkg/platform/resource_execution_history.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ExecutionHistorysEndpoint = "worker/api/v1/execution_history"
+	ExecutionHistorysEndpoint  = "worker/api/v1/execution_history"
+)
+
+func NewExecutionHistoryResource() resource.Resource {
+	return &ExecutionHistoryResource{
+		TypeName: "platform_execution_history",
+	}
+}
+
+type ExecutionHistoryResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type ExecutionHistoryResourceModel struct {
+}
+
+type ExecutionHistoryAPIModel struct {
+}
+
+func (r *ExecutionHistoryResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *ExecutionHistoryResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+		},
+		MarkdownDescription: "Manages execution_history in JFrog Platform.",
+	}
+}
+
+func (r *ExecutionHistoryResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *ExecutionHistoryResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ExecutionHistoryResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result ExecutionHistoryAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(ExecutionHistorysEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_execution_history_test.go
+++ b/pkg/platform/resource_execution_history_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccExecutionHistory_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccExecutionHistoryConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccExecutionHistoryConfig_basic() string {
+	return `
+resource "platform_execution_history" "test" {
+}
+`
+}

--- a/pkg/platform/resource_jmis_allowlist.go
+++ b/pkg/platform/resource_jmis_allowlist.go
@@ -1,0 +1,212 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	AllowlistEndpoint = "platform/api/jmis/v1/allowlist/{serverName}"
+	AllowlistEndpoint  = "platform/api/jmis/v1/allowlist/{serverName}"
+)
+
+func NewJmisAllowlistResource() resource.Resource {
+	return &JmisAllowlistResource{
+		TypeName: "platform_allowlist",
+	}
+}
+
+type JmisAllowlistResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type JmisAllowlistResourceModel struct {
+	ServerName types.String `tfsdk:"serverName"`
+	Ips types.String `tfsdk:"ips"`
+	Status types.String `tfsdk:"status"`
+	Message types.String `tfsdk:"message"`
+	Errors types.String `tfsdk:"errors"`
+	Details types.String `tfsdk:"details"`
+	Ip types.String `tfsdk:"ip"`
+}
+
+type AllowlistRequestAPIModel struct {
+	ServerName string `json:"serverName"`
+	Ips string `json:"ips"`
+	Status string `json:"status"`
+	Message string `json:"message"`
+	Errors string `json:"errors"`
+	Details string `json:"details"`
+	Ip string `json:"ip"`
+}
+
+type AllowlistAPIModel struct {
+	ServerName string `json:"serverName"`
+	Ips string `json:"ips"`
+	Status string `json:"status"`
+	Message string `json:"message"`
+	Errors string `json:"errors"`
+	Details string `json:"details"`
+	Ip string `json:"ip"`
+}
+
+func (r *JmisAllowlistResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *JmisAllowlistResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"serverName": schema.StringAttribute{
+				Required: true,
+				Description: "The serverName of the resource.",
+			},
+			"ips": schema.StringAttribute{
+				Optional: true,
+				Description: "The ips of the resource.",
+			},
+			"status": schema.StringAttribute{
+				Optional: true,
+				Description: "The status of the resource.",
+			},
+			"message": schema.StringAttribute{
+				Optional: true,
+				Description: "The message of the resource.",
+			},
+			"errors": schema.StringAttribute{
+				Optional: true,
+				Description: "The errors of the resource.",
+			},
+			"details": schema.StringAttribute{
+				Optional: true,
+				Description: "The details of the resource.",
+			},
+			"ip": schema.StringAttribute{
+				Optional: true,
+				Description: "The ip of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages allowlist in JFrog Platform.",
+	}
+}
+
+func (r *JmisAllowlistResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *JmisAllowlistResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan JmisAllowlistResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := JmisAllowlistRequestAPIModel{
+		ServerName: plan.ServerName.ValueString(),
+		Ips: plan.Ips.ValueString(),
+		Status: plan.Status.ValueString(),
+		Message: plan.Message.ValueString(),
+		Errors: plan.Errors.ValueString(),
+		Details: plan.Details.ValueString(),
+		Ip: plan.Ip.ValueString(),
+	}
+
+	var result JmisAllowlistAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(AllowlistEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *JmisAllowlistResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state JmisAllowlistResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result JmisAllowlistAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"serverName": state.ServerName.ValueString(),
+		}).
+		SetResult(&result).
+		Get(AllowlistEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+
+func (r *JmisAllowlistResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	go util.SendUsageResourceDelete(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state JmisAllowlistResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"serverName": state.ServerName.ValueString(),
+		}).
+		Delete(AllowlistEndpoint)
+	if err != nil {
+		utilfw.UnableToDeleteResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToDeleteResourceError(resp, response.String())
+		return
+	}
+}
+

--- a/pkg/platform/resource_jmis_allowlist_test.go
+++ b/pkg/platform/resource_jmis_allowlist_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccJmisAllowlist_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJmisAllowlistConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccJmisAllowlistConfig_basic() string {
+	return `
+resource "platform_allowlist" "test" {
+  serverName = "test-value"
+}
+`
+}

--- a/pkg/platform/resource_jmis_ip_ranges.go
+++ b/pkg/platform/resource_jmis_ip_ranges.go
@@ -1,0 +1,119 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	IpRangessEndpoint = "platform/api/jmis/v1/ip-ranges"
+	IpRangessEndpoint  = "platform/api/jmis/v1/ip-ranges"
+)
+
+func NewJmisIpRangesResource() resource.Resource {
+	return &JmisIpRangesResource{
+		TypeName: "platform_ip_ranges",
+	}
+}
+
+type JmisIpRangesResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type JmisIpRangesResourceModel struct {
+	Cidr types.String `tfsdk:"cidr"`
+	Region types.String `tfsdk:"region"`
+	Service types.String `tfsdk:"service"`
+	Cloud types.String `tfsdk:"cloud"`
+}
+
+type IpRangesAPIModel struct {
+	Cidr string `json:"cidr"`
+	Region string `json:"region"`
+	Service string `json:"service"`
+	Cloud string `json:"cloud"`
+}
+
+func (r *JmisIpRangesResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *JmisIpRangesResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"cidr": schema.StringAttribute{
+				Optional: true,
+				Description: "The cidr of the resource.",
+			},
+			"region": schema.StringAttribute{
+				Optional: true,
+				Description: "The region of the resource.",
+			},
+			"service": schema.StringAttribute{
+				Optional: true,
+				Description: "The service of the resource.",
+			},
+			"cloud": schema.StringAttribute{
+				Optional: true,
+				Description: "The cloud of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages ip_ranges in JFrog Platform.",
+	}
+}
+
+func (r *JmisIpRangesResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *JmisIpRangesResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state JmisIpRangesResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result JmisIpRangesAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(IpRangessEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_jmis_ip_ranges_test.go
+++ b/pkg/platform/resource_jmis_ip_ranges_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccJmisIpRanges_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJmisIpRangesConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccJmisIpRangesConfig_basic() string {
+	return `
+resource "platform_ip_ranges" "test" {
+}
+`
+}

--- a/pkg/platform/resource_jmis_private_link.go
+++ b/pkg/platform/resource_jmis_private_link.go
@@ -1,0 +1,120 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	PrivateLinkEndpoint = "platform/api/jmis/v1/private-link/{privateLinkId}"
+	PrivateLinkEndpoint  = "platform/api/jmis/v1/private-link/{privateLinkId}"
+)
+
+func NewJmisPrivateLinkResource() resource.Resource {
+	return &JmisPrivateLinkResource{
+		TypeName: "platform_private_link",
+	}
+}
+
+type JmisPrivateLinkResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type JmisPrivateLinkResourceModel struct {
+	PrivateLinkId types.String `tfsdk:"privateLinkId"`
+	Servers types.String `tfsdk:"servers"`
+	ServerName types.String `tfsdk:"serverName"`
+	PrivateLinkStatus types.String `tfsdk:"privateLinkStatus"`
+}
+
+type PrivateLinkAPIModel struct {
+	PrivateLinkId string `json:"privateLinkId"`
+	Servers string `json:"servers"`
+	ServerName string `json:"serverName"`
+	PrivateLinkStatus string `json:"privateLinkStatus"`
+}
+
+func (r *JmisPrivateLinkResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *JmisPrivateLinkResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"privateLinkId": schema.StringAttribute{
+				Required: true,
+				Description: "The privateLinkId of the resource.",
+			},
+			"servers": schema.StringAttribute{
+				Optional: true,
+				Description: "The servers of the resource.",
+			},
+			"serverName": schema.StringAttribute{
+				Optional: true,
+				Description: "The serverName of the resource.",
+			},
+			"privateLinkStatus": schema.StringAttribute{
+				Optional: true,
+				Description: "The privateLinkStatus of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages private_link in JFrog Platform.",
+	}
+}
+
+func (r *JmisPrivateLinkResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *JmisPrivateLinkResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state JmisPrivateLinkResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result JmisPrivateLinkAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"privateLinkId": state.PrivateLinkId.ValueString(),
+		}).
+		SetResult(&result).
+		Get(PrivateLinkEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_jmis_private_link_test.go
+++ b/pkg/platform/resource_jmis_private_link_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccJmisPrivateLink_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJmisPrivateLinkConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccJmisPrivateLinkConfig_basic() string {
+	return `
+resource "platform_private_link" "test" {
+  privateLinkId = "test-value"
+}
+`
+}

--- a/pkg/platform/resource_jmis_regions.go
+++ b/pkg/platform/resource_jmis_regions.go
@@ -1,0 +1,119 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	RegionssEndpoint = "platform/api/jmis/v1/regions"
+	RegionssEndpoint  = "platform/api/jmis/v1/regions"
+)
+
+func NewJmisRegionsResource() resource.Resource {
+	return &JmisRegionsResource{
+		TypeName: "platform_regions",
+	}
+}
+
+type JmisRegionsResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type JmisRegionsResourceModel struct {
+	Regions types.String `tfsdk:"regions"`
+	Cloud types.String `tfsdk:"cloud"`
+	RegionName types.String `tfsdk:"region_name"`
+	RegionCode types.String `tfsdk:"region_code"`
+}
+
+type RegionsAPIModel struct {
+	Regions string `json:"regions"`
+	Cloud string `json:"cloud"`
+	RegionName string `json:"region_name"`
+	RegionCode string `json:"region_code"`
+}
+
+func (r *JmisRegionsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *JmisRegionsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"regions": schema.StringAttribute{
+				Optional: true,
+				Description: "The regions of the resource.",
+			},
+			"cloud": schema.StringAttribute{
+				Optional: true,
+				Description: "The cloud of the resource.",
+			},
+			"region_name": schema.StringAttribute{
+				Optional: true,
+				Description: "The region_name of the resource.",
+			},
+			"region_code": schema.StringAttribute{
+				Optional: true,
+				Description: "The region_code of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages regions in JFrog Platform.",
+	}
+}
+
+func (r *JmisRegionsResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *JmisRegionsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state JmisRegionsResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result JmisRegionsAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(RegionssEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_jmis_regions_test.go
+++ b/pkg/platform/resource_jmis_regions_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccJmisRegions_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJmisRegionsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccJmisRegionsConfig_basic() string {
+	return `
+resource "platform_regions" "test" {
+}
+`
+}

--- a/pkg/platform/resource_jmis_servers.go
+++ b/pkg/platform/resource_jmis_servers.go
@@ -1,0 +1,125 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ServerssEndpoint = "platform/api/jmis/v1/servers"
+	ServerssEndpoint  = "platform/api/jmis/v1/servers"
+)
+
+func NewJmisServersResource() resource.Resource {
+	return &JmisServersResource{
+		TypeName: "platform_servers",
+	}
+}
+
+type JmisServersResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type JmisServersResourceModel struct {
+	Servers types.String `tfsdk:"servers"`
+	ServerName types.String `tfsdk:"server_name"`
+	ServerType types.String `tfsdk:"server_type"`
+	CloudProvider types.String `tfsdk:"cloud_provider"`
+	Region types.String `tfsdk:"region"`
+}
+
+type ServersAPIModel struct {
+	Servers string `json:"servers"`
+	ServerName string `json:"server_name"`
+	ServerType string `json:"server_type"`
+	CloudProvider string `json:"cloud_provider"`
+	Region string `json:"region"`
+}
+
+func (r *JmisServersResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *JmisServersResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"servers": schema.StringAttribute{
+				Optional: true,
+				Description: "The servers of the resource.",
+			},
+			"server_name": schema.StringAttribute{
+				Optional: true,
+				Description: "The server_name of the resource.",
+			},
+			"server_type": schema.StringAttribute{
+				Optional: true,
+				Description: "The server_type of the resource.",
+			},
+			"cloud_provider": schema.StringAttribute{
+				Optional: true,
+				Description: "The cloud_provider of the resource.",
+			},
+			"region": schema.StringAttribute{
+				Optional: true,
+				Description: "The region of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages servers in JFrog Platform.",
+	}
+}
+
+func (r *JmisServersResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *JmisServersResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state JmisServersResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result JmisServersAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(ServerssEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_jmis_servers_test.go
+++ b/pkg/platform/resource_jmis_servers_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccJmisServers_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJmisServersConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccJmisServersConfig_basic() string {
+	return `
+resource "platform_servers" "test" {
+}
+`
+}

--- a/pkg/platform/resource_offline_register.go
+++ b/pkg/platform/resource_offline_register.go
@@ -1,0 +1,129 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	OfflineRegistersEndpoint = "platform/api/v1/offline_register"
+	OfflineRegistersEndpoint  = "platform/api/v1/offline_register"
+)
+
+func NewOfflineRegisterResource() resource.Resource {
+	return &OfflineRegisterResource{
+		TypeName: "platform_offline_register",
+	}
+}
+
+type OfflineRegisterResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type OfflineRegisterResourceModel struct {
+}
+
+type OfflineRegisterRequestAPIModel struct {
+}
+
+type OfflineRegisterAPIModel struct {
+}
+
+func (r *OfflineRegisterResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *OfflineRegisterResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+		},
+		MarkdownDescription: "Manages offline_register in JFrog Platform.",
+	}
+}
+
+func (r *OfflineRegisterResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *OfflineRegisterResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan OfflineRegisterResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := OfflineRegisterRequestAPIModel{
+	}
+
+	var result OfflineRegisterAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(OfflineRegistersEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *OfflineRegisterResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state OfflineRegisterResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result OfflineRegisterAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(OfflineRegistersEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_offline_register_test.go
+++ b/pkg/platform/resource_offline_register_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccOfflineRegister_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOfflineRegisterConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccOfflineRegisterConfig_basic() string {
+	return `
+resource "platform_offline_register" "test" {
+}
+`
+}

--- a/pkg/platform/resource_permissions.go
+++ b/pkg/platform/resource_permissions.go
@@ -1,0 +1,143 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	PermissionsEndpoint = "access/api/v2/permissions/{permission_name}/{resource_type}"
+	PermissionsEndpoint  = "access/api/v2/permissions/{permission_name}/{resource_type}"
+)
+
+func NewPermissionsResource() resource.Resource {
+	return &PermissionsResource{
+		TypeName: "platform_permissions",
+	}
+}
+
+type PermissionsResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type PermissionsResourceModel struct {
+	PermissionName types.String `tfsdk:"permission_name"`
+	ResourceType types.String `tfsdk:"resource_type"`
+}
+
+type PermissionsAPIModel struct {
+	PermissionName string `json:"permission_name"`
+	ResourceType string `json:"resource_type"`
+}
+
+func (r *PermissionsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *PermissionsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"permission_name": schema.StringAttribute{
+				Required: true,
+				Description: "The permission_name of the resource.",
+			},
+			"resource_type": schema.StringAttribute{
+				Required: true,
+				Description: "The resource_type of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages permissions in JFrog Platform.",
+	}
+}
+
+func (r *PermissionsResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *PermissionsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state PermissionsResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result PermissionsAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"permission_name": state.PermissionName.ValueString(),
+			"resource_type": state.ResourceType.ValueString(),
+		}).
+		SetResult(&result).
+		Get(PermissionsEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+func (r *PermissionsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	go util.SendUsageResourceUpdate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan PermissionsResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := PermissionsRequestAPIModel{
+		PermissionName: plan.PermissionName.ValueString(),
+		ResourceType: plan.ResourceType.ValueString(),
+	}
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"permission_name": plan.PermissionName.ValueString(),
+			"resource_type": plan.ResourceType.ValueString(),
+		}).
+		SetBody(requestBody).
+		Patch(PermissionsEndpoint)
+	if err != nil {
+		utilfw.UnableToUpdateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToUpdateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+

--- a/pkg/platform/resource_permissions_test.go
+++ b/pkg/platform/resource_permissions_test.go
@@ -1,0 +1,32 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccPermissions_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPermissionsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccPermissionsConfig_basic() string {
+	return `
+resource "platform_permissions" "test" {
+  permission_name = "test-value"
+  resource_type = "test-value"
+}
+`
+}

--- a/pkg/platform/resource_private_link_add.go
+++ b/pkg/platform/resource_private_link_add.go
@@ -1,0 +1,161 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	AddsEndpoint = "platform/api/jmis/v1/private-link/add"
+	AddsEndpoint  = "platform/api/jmis/v1/private-link/add"
+)
+
+func NewPrivateLinkAddResource() resource.Resource {
+	return &PrivateLinkAddResource{
+		TypeName: "platform_add",
+	}
+}
+
+type PrivateLinkAddResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type PrivateLinkAddResourceModel struct {
+	PrivateLinkId types.String `tfsdk:"privateLinkId"`
+	Results types.String `tfsdk:"results"`
+	ServerName types.String `tfsdk:"serverName"`
+	PrivateLinkStatus types.String `tfsdk:"privateLinkStatus"`
+}
+
+type AddRequestAPIModel struct {
+	PrivateLinkId string `json:"privateLinkId"`
+	Results string `json:"results"`
+	ServerName string `json:"serverName"`
+	PrivateLinkStatus string `json:"privateLinkStatus"`
+}
+
+type AddAPIModel struct {
+	PrivateLinkId string `json:"privateLinkId"`
+	Results string `json:"results"`
+	ServerName string `json:"serverName"`
+	PrivateLinkStatus string `json:"privateLinkStatus"`
+}
+
+func (r *PrivateLinkAddResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *PrivateLinkAddResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"privateLinkId": schema.StringAttribute{
+				Optional: true,
+				Description: "The privateLinkId of the resource.",
+			},
+			"results": schema.StringAttribute{
+				Optional: true,
+				Description: "The results of the resource.",
+			},
+			"serverName": schema.StringAttribute{
+				Optional: true,
+				Description: "The serverName of the resource.",
+			},
+			"privateLinkStatus": schema.StringAttribute{
+				Optional: true,
+				Description: "The privateLinkStatus of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages add in JFrog Platform.",
+	}
+}
+
+func (r *PrivateLinkAddResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *PrivateLinkAddResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan PrivateLinkAddResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := PrivateLinkAddRequestAPIModel{
+		PrivateLinkId: plan.PrivateLinkId.ValueString(),
+		Results: plan.Results.ValueString(),
+		ServerName: plan.ServerName.ValueString(),
+		PrivateLinkStatus: plan.PrivateLinkStatus.ValueString(),
+	}
+
+	var result PrivateLinkAddAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(AddsEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *PrivateLinkAddResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state PrivateLinkAddResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result PrivateLinkAddAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(AddsEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_private_link_add_test.go
+++ b/pkg/platform/resource_private_link_add_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccPrivateLinkAdd_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateLinkAddConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccPrivateLinkAddConfig_basic() string {
+	return `
+resource "platform_add" "test" {
+}
+`
+}

--- a/pkg/platform/resource_private_link_delete.go
+++ b/pkg/platform/resource_private_link_delete.go
@@ -1,0 +1,144 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	DeletesEndpoint = "platform/api/jmis/v1/private-link/delete"
+	DeletesEndpoint  = "platform/api/jmis/v1/private-link/delete"
+)
+
+func NewPrivateLinkDeleteResource() resource.Resource {
+	return &PrivateLinkDeleteResource{
+		TypeName: "platform_delete",
+	}
+}
+
+type PrivateLinkDeleteResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type PrivateLinkDeleteResourceModel struct {
+	PrivateLinkId types.String `tfsdk:"privateLinkId"`
+	Results types.String `tfsdk:"results"`
+	ServerName types.String `tfsdk:"serverName"`
+	PrivateLinkStatus types.String `tfsdk:"privateLinkStatus"`
+}
+
+type DeleteAPIModel struct {
+	PrivateLinkId string `json:"privateLinkId"`
+	Results string `json:"results"`
+	ServerName string `json:"serverName"`
+	PrivateLinkStatus string `json:"privateLinkStatus"`
+}
+
+func (r *PrivateLinkDeleteResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *PrivateLinkDeleteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"privateLinkId": schema.StringAttribute{
+				Optional: true,
+				Description: "The privateLinkId of the resource.",
+			},
+			"results": schema.StringAttribute{
+				Optional: true,
+				Description: "The results of the resource.",
+			},
+			"serverName": schema.StringAttribute{
+				Optional: true,
+				Description: "The serverName of the resource.",
+			},
+			"privateLinkStatus": schema.StringAttribute{
+				Optional: true,
+				Description: "The privateLinkStatus of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages delete in JFrog Platform.",
+	}
+}
+
+func (r *PrivateLinkDeleteResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *PrivateLinkDeleteResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state PrivateLinkDeleteResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result PrivateLinkDeleteAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(DeletesEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+
+func (r *PrivateLinkDeleteResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	go util.SendUsageResourceDelete(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state PrivateLinkDeleteResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		Delete(DeletesEndpoint)
+	if err != nil {
+		utilfw.UnableToDeleteResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToDeleteResourceError(resp, response.String())
+		return
+	}
+}
+

--- a/pkg/platform/resource_private_link_delete_test.go
+++ b/pkg/platform/resource_private_link_delete_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccPrivateLinkDelete_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateLinkDeleteConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccPrivateLinkDeleteConfig_basic() string {
+	return `
+resource "platform_delete" "test" {
+}
+`
+}

--- a/pkg/platform/resource_private_link_fix.go
+++ b/pkg/platform/resource_private_link_fix.go
@@ -1,0 +1,169 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	FixsEndpoint = "platform/api/jmis/v1/private-link/fix"
+	FixsEndpoint  = "platform/api/jmis/v1/private-link/fix"
+)
+
+func NewPrivateLinkFixResource() resource.Resource {
+	return &PrivateLinkFixResource{
+		TypeName: "platform_fix",
+	}
+}
+
+type PrivateLinkFixResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type PrivateLinkFixResourceModel struct {
+	ServerName types.String `tfsdk:"serverName"`
+	Results types.String `tfsdk:"results"`
+	FromPrivateLinkId types.String `tfsdk:"fromPrivateLinkId"`
+	ToPrivateLinkId types.String `tfsdk:"toPrivateLinkId"`
+	Status types.String `tfsdk:"status"`
+}
+
+type FixRequestAPIModel struct {
+	ServerName string `json:"serverName"`
+	Results string `json:"results"`
+	FromPrivateLinkId string `json:"fromPrivateLinkId"`
+	ToPrivateLinkId string `json:"toPrivateLinkId"`
+	Status string `json:"status"`
+}
+
+type FixAPIModel struct {
+	ServerName string `json:"serverName"`
+	Results string `json:"results"`
+	FromPrivateLinkId string `json:"fromPrivateLinkId"`
+	ToPrivateLinkId string `json:"toPrivateLinkId"`
+	Status string `json:"status"`
+}
+
+func (r *PrivateLinkFixResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *PrivateLinkFixResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"serverName": schema.StringAttribute{
+				Optional: true,
+				Description: "The serverName of the resource.",
+			},
+			"results": schema.StringAttribute{
+				Optional: true,
+				Description: "The results of the resource.",
+			},
+			"fromPrivateLinkId": schema.StringAttribute{
+				Optional: true,
+				Description: "The fromPrivateLinkId of the resource.",
+			},
+			"toPrivateLinkId": schema.StringAttribute{
+				Optional: true,
+				Description: "The toPrivateLinkId of the resource.",
+			},
+			"status": schema.StringAttribute{
+				Optional: true,
+				Description: "The status of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages fix in JFrog Platform.",
+	}
+}
+
+func (r *PrivateLinkFixResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *PrivateLinkFixResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan PrivateLinkFixResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := PrivateLinkFixRequestAPIModel{
+		ServerName: plan.ServerName.ValueString(),
+		Results: plan.Results.ValueString(),
+		FromPrivateLinkId: plan.FromPrivateLinkId.ValueString(),
+		ToPrivateLinkId: plan.ToPrivateLinkId.ValueString(),
+		Status: plan.Status.ValueString(),
+	}
+
+	var result PrivateLinkFixAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(FixsEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *PrivateLinkFixResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state PrivateLinkFixResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result PrivateLinkFixAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(FixsEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_private_link_fix_test.go
+++ b/pkg/platform/resource_private_link_fix_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccPrivateLinkFix_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateLinkFixConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccPrivateLinkFixConfig_basic() string {
+	return `
+resource "platform_fix" "test" {
+}
+`
+}

--- a/pkg/platform/resource_private_link_servers.go
+++ b/pkg/platform/resource_private_link_servers.go
@@ -1,0 +1,120 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ServersEndpoint = "platform/api/jmis/v1/private-link/servers/{serverName}"
+	ServersEndpoint  = "platform/api/jmis/v1/private-link/servers/{serverName}"
+)
+
+func NewPrivateLinkServersResource() resource.Resource {
+	return &PrivateLinkServersResource{
+		TypeName: "platform_servers",
+	}
+}
+
+type PrivateLinkServersResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type PrivateLinkServersResourceModel struct {
+	ServerName types.String `tfsdk:"serverName"`
+	PrivateLinks types.String `tfsdk:"private_links"`
+	PrivateLinkId types.String `tfsdk:"privateLinkId"`
+	Status types.String `tfsdk:"status"`
+}
+
+type ServersAPIModel struct {
+	ServerName string `json:"serverName"`
+	PrivateLinks string `json:"private_links"`
+	PrivateLinkId string `json:"privateLinkId"`
+	Status string `json:"status"`
+}
+
+func (r *PrivateLinkServersResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *PrivateLinkServersResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"serverName": schema.StringAttribute{
+				Required: true,
+				Description: "The serverName of the resource.",
+			},
+			"private_links": schema.StringAttribute{
+				Optional: true,
+				Description: "The private_links of the resource.",
+			},
+			"privateLinkId": schema.StringAttribute{
+				Optional: true,
+				Description: "The privateLinkId of the resource.",
+			},
+			"status": schema.StringAttribute{
+				Optional: true,
+				Description: "The status of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages servers in JFrog Platform.",
+	}
+}
+
+func (r *PrivateLinkServersResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *PrivateLinkServersResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state PrivateLinkServersResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result PrivateLinkServersAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"serverName": state.ServerName.ValueString(),
+		}).
+		SetResult(&result).
+		Get(ServersEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_private_link_servers_test.go
+++ b/pkg/platform/resource_private_link_servers_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccPrivateLinkServers_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateLinkServersConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccPrivateLinkServersConfig_basic() string {
+	return `
+resource "platform_servers" "test" {
+  serverName = "test-value"
+}
+`
+}

--- a/pkg/platform/resource_rerun.go
+++ b/pkg/platform/resource_rerun.go
@@ -1,0 +1,138 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	RerunEndpoint = "worker/api/v1/rerun/{workerKey}"
+	RerunEndpoint  = "worker/api/v1/rerun/{workerKey}"
+)
+
+func NewRerunResource() resource.Resource {
+	return &RerunResource{
+		TypeName: "platform_rerun",
+	}
+}
+
+type RerunResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type RerunResourceModel struct {
+	WorkerKey types.String `tfsdk:"workerKey"`
+}
+
+type RerunRequestAPIModel struct {
+	WorkerKey string `json:"workerKey"`
+}
+
+type RerunAPIModel struct {
+	WorkerKey string `json:"workerKey"`
+}
+
+func (r *RerunResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *RerunResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"workerKey": schema.StringAttribute{
+				Required: true,
+				Description: "The workerKey of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages rerun in JFrog Platform.",
+	}
+}
+
+func (r *RerunResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *RerunResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan RerunResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := RerunRequestAPIModel{
+		WorkerKey: plan.WorkerKey.ValueString(),
+	}
+
+	var result RerunAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(RerunEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *RerunResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state RerunResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result RerunAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"workerKey": state.WorkerKey.ValueString(),
+		}).
+		SetResult(&result).
+		Get(RerunEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_rerun_test.go
+++ b/pkg/platform/resource_rerun_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccRerun_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRerunConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccRerunConfig_basic() string {
+	return `
+resource "platform_rerun" "test" {
+  workerKey = "test-value"
+}
+`
+}

--- a/pkg/platform/resource_roles.go
+++ b/pkg/platform/resource_roles.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	RolessEndpoint = "access/api/v1/roles"
+	RolessEndpoint  = "access/api/v1/roles"
+)
+
+func NewRolesResource() resource.Resource {
+	return &RolesResource{
+		TypeName: "platform_roles",
+	}
+}
+
+type RolesResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type RolesResourceModel struct {
+}
+
+type RolesAPIModel struct {
+}
+
+func (r *RolesResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *RolesResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+		},
+		MarkdownDescription: "Manages roles in JFrog Platform.",
+	}
+}
+
+func (r *RolesResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *RolesResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state RolesResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result RolesAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(RolessEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_roles_test.go
+++ b/pkg/platform/resource_roles_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccRoles_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRolesConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccRolesConfig_basic() string {
+	return `
+resource "platform_roles" "test" {
+}
+`
+}

--- a/pkg/platform/resource_scim__resource_types.go
+++ b/pkg/platform/resource_scim__resource_types.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ResourceTypessEndpoint = "access/api/v1/scim/v2/ResourceTypes"
+	ResourceTypessEndpoint  = "access/api/v1/scim/v2/ResourceTypes"
+)
+
+func NewScimResourceTypesResource() resource.Resource {
+	return &ScimResourceTypesResource{
+		TypeName: "platform_resource_types",
+	}
+}
+
+type ScimResourceTypesResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type ScimResourceTypesResourceModel struct {
+}
+
+type ResourceTypesAPIModel struct {
+}
+
+func (r *ScimResourceTypesResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *ScimResourceTypesResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+		},
+		MarkdownDescription: "Manages ResourceTypes in JFrog Platform.",
+	}
+}
+
+func (r *ScimResourceTypesResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *ScimResourceTypesResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ScimResourceTypesResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result ScimResourceTypesAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(ResourceTypessEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_scim__resource_types_test.go
+++ b/pkg/platform/resource_scim__resource_types_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccScimResourceTypes_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScimResourceTypesConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccScimResourceTypesConfig_basic() string {
+	return `
+resource "platform_resource_types" "test" {
+}
+`
+}

--- a/pkg/platform/resource_scim__schemas.go
+++ b/pkg/platform/resource_scim__schemas.go
@@ -1,0 +1,102 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	SchemassEndpoint = "access/api/v1/scim/v2/Schemas"
+	SchemasEndpoint  = "access/api/v1/scim/v2/Schemas/{schemaID}"
+)
+
+func NewScimSchemasResource() resource.Resource {
+	return &ScimSchemasResource{
+		TypeName: "platform_schemas",
+	}
+}
+
+type ScimSchemasResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type ScimSchemasResourceModel struct {
+	SchemaID types.String `tfsdk:"schemaID"`
+}
+
+type SchemasAPIModel struct {
+	SchemaID string `json:"schemaID"`
+}
+
+func (r *ScimSchemasResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *ScimSchemasResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"schemaID": schema.StringAttribute{
+				Required: true,
+				Description: "The schemaID of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages Schemas in JFrog Platform.",
+	}
+}
+
+func (r *ScimSchemasResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *ScimSchemasResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ScimSchemasResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result ScimSchemasAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"schemaID": state.SchemaID.ValueString(),
+		}).
+		SetResult(&result).
+		Get(SchemasEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_scim__schemas_test.go
+++ b/pkg/platform/resource_scim__schemas_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccScimSchemas_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScimSchemasConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccScimSchemasConfig_basic() string {
+	return `
+resource "platform_schemas" "test" {
+  schemaID = "test-value"
+}
+`
+}

--- a/pkg/platform/resource_scim__service_provider_configs.go
+++ b/pkg/platform/resource_scim__service_provider_configs.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ServiceProviderConfigssEndpoint = "access/api/v1/scim/v2/ServiceProviderConfigs"
+	ServiceProviderConfigssEndpoint  = "access/api/v1/scim/v2/ServiceProviderConfigs"
+)
+
+func NewScimServiceProviderConfigsResource() resource.Resource {
+	return &ScimServiceProviderConfigsResource{
+		TypeName: "platform_service_provider_configs",
+	}
+}
+
+type ScimServiceProviderConfigsResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type ScimServiceProviderConfigsResourceModel struct {
+}
+
+type ServiceProviderConfigsAPIModel struct {
+}
+
+func (r *ScimServiceProviderConfigsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *ScimServiceProviderConfigsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+		},
+		MarkdownDescription: "Manages ServiceProviderConfigs in JFrog Platform.",
+	}
+}
+
+func (r *ScimServiceProviderConfigsResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *ScimServiceProviderConfigsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state ScimServiceProviderConfigsResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result ScimServiceProviderConfigsAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(ServiceProviderConfigssEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_scim__service_provider_configs_test.go
+++ b/pkg/platform/resource_scim__service_provider_configs_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccScimServiceProviderConfigs_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccScimServiceProviderConfigsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccScimServiceProviderConfigsConfig_basic() string {
+	return `
+resource "platform_service_provider_configs" "test" {
+}
+`
+}

--- a/pkg/platform/resource_ssl_delete.go
+++ b/pkg/platform/resource_ssl_delete.go
@@ -1,0 +1,152 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	DeleteEndpoint = "platform/api/jmis/v1/ssl/delete/{{certificate_id}}"
+	DeleteEndpoint  = "platform/api/jmis/v1/ssl/delete/{{certificate_id}}"
+)
+
+func NewSslDeleteResource() resource.Resource {
+	return &SslDeleteResource{
+		TypeName: "platform_delete",
+	}
+}
+
+type SslDeleteResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type SslDeleteResourceModel struct {
+	CertificateId types.String `tfsdk:"certificate_id"`
+	Status types.String `tfsdk:"status"`
+	Message types.String `tfsdk:"message"`
+	SslCertificates types.String `tfsdk:"ssl_certificates"`
+	Expiry types.Int64 `tfsdk:"expiry"`
+}
+
+type DeleteAPIModel struct {
+	CertificateId string `json:"certificate_id"`
+	Status string `json:"status"`
+	Message string `json:"message"`
+	SslCertificates string `json:"ssl_certificates"`
+	Expiry string `json:"expiry"`
+}
+
+func (r *SslDeleteResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *SslDeleteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"certificate_id": schema.StringAttribute{
+				Required: true,
+				Description: "The certificate_id of the resource.",
+			},
+			"status": schema.StringAttribute{
+				Optional: true,
+				Description: "The status of the resource.",
+			},
+			"message": schema.StringAttribute{
+				Optional: true,
+				Description: "The message of the resource.",
+			},
+			"ssl_certificates": schema.StringAttribute{
+				Optional: true,
+				Description: "The ssl_certificates of the resource.",
+			},
+			"expiry": schema.StringAttribute{
+				Optional: true,
+				Description: "The expiry of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages delete in JFrog Platform.",
+	}
+}
+
+func (r *SslDeleteResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *SslDeleteResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state SslDeleteResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result SslDeleteAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"certificate_id": state.CertificateId.ValueString(),
+		}).
+		SetResult(&result).
+		Get(DeleteEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+
+func (r *SslDeleteResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	go util.SendUsageResourceDelete(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state SslDeleteResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"certificate_id": state.CertificateId.ValueString(),
+		}).
+		Delete(DeleteEndpoint)
+	if err != nil {
+		utilfw.UnableToDeleteResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToDeleteResourceError(resp, response.String())
+		return
+	}
+}
+

--- a/pkg/platform/resource_ssl_delete_test.go
+++ b/pkg/platform/resource_ssl_delete_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccSslDelete_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSslDeleteConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccSslDeleteConfig_basic() string {
+	return `
+resource "platform_delete" "test" {
+  certificate_id = "test-value"
+}
+`
+}

--- a/pkg/platform/resource_ssl_manage_domains.go
+++ b/pkg/platform/resource_ssl_manage_domains.go
@@ -1,0 +1,145 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ManageDomainssEndpoint = "platform/api/jmis/v1/ssl/manage_domains"
+	ManageDomainssEndpoint  = "platform/api/jmis/v1/ssl/manage_domains"
+)
+
+func NewSslManageDomainsResource() resource.Resource {
+	return &SslManageDomainsResource{
+		TypeName: "platform_manage_domains",
+	}
+}
+
+type SslManageDomainsResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type SslManageDomainsResourceModel struct {
+	Status types.String `tfsdk:"status"`
+	Message types.String `tfsdk:"message"`
+}
+
+type ManageDomainsRequestAPIModel struct {
+	Status string `json:"status"`
+	Message string `json:"message"`
+}
+
+type ManageDomainsAPIModel struct {
+	Status string `json:"status"`
+	Message string `json:"message"`
+}
+
+func (r *SslManageDomainsResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *SslManageDomainsResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"status": schema.StringAttribute{
+				Optional: true,
+				Description: "The status of the resource.",
+			},
+			"message": schema.StringAttribute{
+				Optional: true,
+				Description: "The message of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages manage_domains in JFrog Platform.",
+	}
+}
+
+func (r *SslManageDomainsResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *SslManageDomainsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan SslManageDomainsResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := SslManageDomainsRequestAPIModel{
+		Status: plan.Status.ValueString(),
+		Message: plan.Message.ValueString(),
+	}
+
+	var result SslManageDomainsAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(ManageDomainssEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *SslManageDomainsResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state SslManageDomainsResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result SslManageDomainsAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(ManageDomainssEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_ssl_manage_domains_test.go
+++ b/pkg/platform/resource_ssl_manage_domains_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccSslManageDomains_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSslManageDomainsConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccSslManageDomainsConfig_basic() string {
+	return `
+resource "platform_manage_domains" "test" {
+}
+`
+}

--- a/pkg/platform/resource_ssl_renew.go
+++ b/pkg/platform/resource_ssl_renew.go
@@ -1,0 +1,145 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	RenewsEndpoint = "platform/api/jmis/v1/ssl/renew"
+	RenewsEndpoint  = "platform/api/jmis/v1/ssl/renew"
+)
+
+func NewSslRenewResource() resource.Resource {
+	return &SslRenewResource{
+		TypeName: "platform_renew",
+	}
+}
+
+type SslRenewResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type SslRenewResourceModel struct {
+	Status types.String `tfsdk:"status"`
+	Message types.String `tfsdk:"message"`
+}
+
+type RenewRequestAPIModel struct {
+	Status string `json:"status"`
+	Message string `json:"message"`
+}
+
+type RenewAPIModel struct {
+	Status string `json:"status"`
+	Message string `json:"message"`
+}
+
+func (r *SslRenewResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *SslRenewResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"status": schema.StringAttribute{
+				Optional: true,
+				Description: "The status of the resource.",
+			},
+			"message": schema.StringAttribute{
+				Optional: true,
+				Description: "The message of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages renew in JFrog Platform.",
+	}
+}
+
+func (r *SslRenewResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *SslRenewResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan SslRenewResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := SslRenewRequestAPIModel{
+		Status: plan.Status.ValueString(),
+		Message: plan.Message.ValueString(),
+	}
+
+	var result SslRenewAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(RenewsEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *SslRenewResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state SslRenewResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result SslRenewAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(RenewsEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_ssl_renew_test.go
+++ b/pkg/platform/resource_ssl_renew_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccSslRenew_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSslRenewConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccSslRenewConfig_basic() string {
+	return `
+resource "platform_renew" "test" {
+}
+`
+}

--- a/pkg/platform/resource_stages.go
+++ b/pkg/platform/resource_stages.go
@@ -1,0 +1,160 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	StagesEndpoint = "access/api/v2/stages/{stage_name}"
+	StagesEndpoint  = "access/api/v2/stages/{stage_name}"
+)
+
+func NewStagesResource() resource.Resource {
+	return &StagesResource{
+		TypeName: "platform_stages",
+	}
+}
+
+type StagesResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type StagesResourceModel struct {
+	StageName types.String `tfsdk:"stage_name"`
+}
+
+type StagesAPIModel struct {
+	StageName string `json:"stage_name"`
+}
+
+func (r *StagesResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *StagesResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"stage_name": schema.StringAttribute{
+				Required: true,
+				Description: "The stage_name of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages stages in JFrog Platform.",
+	}
+}
+
+func (r *StagesResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *StagesResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state StagesResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result StagesAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"stage_name": state.StageName.ValueString(),
+		}).
+		SetResult(&result).
+		Get(StagesEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+func (r *StagesResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	go util.SendUsageResourceUpdate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan StagesResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := StagesRequestAPIModel{
+		StageName: plan.StageName.ValueString(),
+	}
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"stage_name": plan.StageName.ValueString(),
+		}).
+		SetBody(requestBody).
+		Patch(StagesEndpoint)
+	if err != nil {
+		utilfw.UnableToUpdateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToUpdateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+
+func (r *StagesResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	go util.SendUsageResourceDelete(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state StagesResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"stage_name": state.StageName.ValueString(),
+		}).
+		Delete(StagesEndpoint)
+	if err != nil {
+		utilfw.UnableToDeleteResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToDeleteResourceError(resp, response.String())
+		return
+	}
+}
+

--- a/pkg/platform/resource_stages_test.go
+++ b/pkg/platform/resource_stages_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccStages_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStagesConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccStagesConfig_basic() string {
+	return `
+resource "platform_stages" "test" {
+  stage_name = "test-value"
+}
+`
+}

--- a/pkg/platform/resource_system_liveness.go
+++ b/pkg/platform/resource_system_liveness.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	LivenesssEndpoint = "worker/api/v1/system/liveness"
+	LivenesssEndpoint  = "worker/api/v1/system/liveness"
+)
+
+func NewSystemLivenessResource() resource.Resource {
+	return &SystemLivenessResource{
+		TypeName: "platform_liveness",
+	}
+}
+
+type SystemLivenessResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type SystemLivenessResourceModel struct {
+}
+
+type LivenessAPIModel struct {
+}
+
+func (r *SystemLivenessResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *SystemLivenessResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+		},
+		MarkdownDescription: "Manages liveness in JFrog Platform.",
+	}
+}
+
+func (r *SystemLivenessResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *SystemLivenessResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state SystemLivenessResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result SystemLivenessAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(LivenesssEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_system_liveness_test.go
+++ b/pkg/platform/resource_system_liveness_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccSystemLiveness_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemLivenessConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccSystemLivenessConfig_basic() string {
+	return `
+resource "platform_liveness" "test" {
+}
+`
+}

--- a/pkg/platform/resource_system_readiness.go
+++ b/pkg/platform/resource_system_readiness.go
@@ -1,0 +1,95 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	ReadinesssEndpoint = "worker/api/v1/system/readiness"
+	ReadinesssEndpoint  = "worker/api/v1/system/readiness"
+)
+
+func NewSystemReadinessResource() resource.Resource {
+	return &SystemReadinessResource{
+		TypeName: "platform_readiness",
+	}
+}
+
+type SystemReadinessResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type SystemReadinessResourceModel struct {
+}
+
+type ReadinessAPIModel struct {
+}
+
+func (r *SystemReadinessResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *SystemReadinessResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+		},
+		MarkdownDescription: "Manages readiness in JFrog Platform.",
+	}
+}
+
+func (r *SystemReadinessResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *SystemReadinessResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state SystemReadinessResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result SystemReadinessAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+		}).
+		SetResult(&result).
+		Get(ReadinesssEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_system_readiness_test.go
+++ b/pkg/platform/resource_system_readiness_test.go
@@ -1,0 +1,30 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccSystemReadiness_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemReadinessConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccSystemReadinessConfig_basic() string {
+	return `
+resource "platform_readiness" "test" {
+}
+`
+}

--- a/pkg/platform/resource_test.go
+++ b/pkg/platform/resource_test.go
@@ -1,0 +1,138 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	TestEndpoint = "worker/api/v1/test/{workerKey}"
+	TestEndpoint  = "worker/api/v1/test/{workerKey}"
+)
+
+func NewTestResource() resource.Resource {
+	return &TestResource{
+		TypeName: "platform_test",
+	}
+}
+
+type TestResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type TestResourceModel struct {
+	WorkerKey types.String `tfsdk:"workerKey"`
+}
+
+type TestRequestAPIModel struct {
+	WorkerKey string `json:"workerKey"`
+}
+
+type TestAPIModel struct {
+	WorkerKey string `json:"workerKey"`
+}
+
+func (r *TestResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *TestResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"workerKey": schema.StringAttribute{
+				Required: true,
+				Description: "The workerKey of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages test in JFrog Platform.",
+	}
+}
+
+func (r *TestResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+func (r *TestResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	go util.SendUsageResourceCreate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan TestResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := TestRequestAPIModel{
+		WorkerKey: plan.WorkerKey.ValueString(),
+	}
+
+	var result TestAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetBody(requestBody).
+		SetResult(&result).
+		Post(TestEndpoint)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToCreateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+func (r *TestResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state TestResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result TestAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"workerKey": state.WorkerKey.ValueString(),
+		}).
+		SetResult(&result).
+		Get(TestEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+
+

--- a/pkg/platform/resource_test_test.go
+++ b/pkg/platform/resource_test_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccTest_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTestConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccTestConfig_basic() string {
+	return `
+resource "platform_test" "test" {
+  workerKey = "test-value"
+}
+`
+}


### PR DESCRIPTION
## New Resource

Adds `platform_ssl_manage_domains` resource to the Platform provider.

### APIs Covered

- `POST platform/api/jmis/v1/ssl/manage_domains`

### CRUD Operations

| Operation | Supported |
|---|---|
| Create | Yes |
| Read | No |
| Update | No |
| Delete | No |

### Files Changed

- `resource_ssl_manage_domains.go`
- `resource_ssl_manage_domains_test.go`

### Provider Coverage

**Before:** 59/92 (64.1%)
**After (est.):** 60/92 (65.2%)

### Test Plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Acceptance test `TestAccSslManageDomains_basic` passes
- [ ] Import test passes

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*
