### PR TITLE
[New Resource] Add platform_federation_full_broadcast (U) — 1 APIs

### DIFF
--- a/pkg/platform/resource_federation_full_broadcast.go
+++ b/pkg/platform/resource_federation_full_broadcast.go
@@ -1,0 +1,138 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-shared/util"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
+)
+
+const (
+	FullBroadcastEndpoint = "access/api/v1/system/federation/{federation_target_servername}/full_broadcast"
+	FullBroadcastEndpoint  = "access/api/v1/system/federation/{federation_target_servername}/full_broadcast"
+)
+
+func NewFederationFullBroadcastResource() resource.Resource {
+	return &FederationFullBroadcastResource{
+		TypeName: "platform_full_broadcast",
+	}
+}
+
+type FederationFullBroadcastResource struct {
+	ProviderData util.ProviderMetadata
+	TypeName     string
+}
+
+type FederationFullBroadcastResourceModel struct {
+	FederationTargetServername types.String `tfsdk:"federation_target_servername"`
+}
+
+type FullBroadcastRequestAPIModel struct {
+	FederationTargetServername string `json:"federation_target_servername"`
+}
+
+type FullBroadcastAPIModel struct {
+	FederationTargetServername string `json:"federation_target_servername"`
+}
+
+func (r *FederationFullBroadcastResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName
+}
+
+func (r *FederationFullBroadcastResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"federation_target_servername": schema.StringAttribute{
+				Required: true,
+				Description: "The federation_target_servername of the resource.",
+			},
+		},
+		MarkdownDescription: "Manages full_broadcast in JFrog Platform.",
+	}
+}
+
+func (r *FederationFullBroadcastResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+
+
+func (r *FederationFullBroadcastResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	go util.SendUsageResourceRead(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var state FederationFullBroadcastResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var result FederationFullBroadcastAPIModel
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"federation_target_servername": state.FederationTargetServername.ValueString(),
+		}).
+		SetResult(&result).
+		Get(FullBroadcastEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+
+func (r *FederationFullBroadcastResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	go util.SendUsageResourceUpdate(ctx, r.ProviderData.Client.R(), r.ProviderData.ProductId, r.TypeName)
+
+	var plan FederationFullBroadcastResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	requestBody := FederationFullBroadcastRequestAPIModel{
+		FederationTargetServername: plan.FederationTargetServername.ValueString(),
+	}
+
+	response, err := r.ProviderData.Client.R().
+		SetPathParams(map[string]string{
+			"federation_target_servername": plan.FederationTargetServername.ValueString(),
+		}).
+		SetBody(requestBody).
+		Put(FullBroadcastEndpoint)
+	if err != nil {
+		utilfw.UnableToUpdateResourceError(resp, err.Error())
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToUpdateResourceError(resp, response.String())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+
+

--- a/pkg/platform/resource_federation_full_broadcast_test.go
+++ b/pkg/platform/resource_federation_full_broadcast_test.go
@@ -1,0 +1,31 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccFederationFullBroadcast_basic(t *testing.T) {
+	// TODO: Implement acceptance test
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { /* testAccPreCheck(t) */ },
+		ProtoV6ProviderFactories: nil, // TODO: set provider factories
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFederationFullBroadcastConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					// TODO: Add checks
+				),
+			},
+		},
+	})
+}
+
+func testAccFederationFullBroadcastConfig_basic() string {
+	return `
+resource "platform_full_broadcast" "test" {
+  federation_target_servername = "test-value"
+}
+`
+}


### PR DESCRIPTION
## Summary

Add `platform_federation_full_broadcast` resource (Update).

### APIs

- `PUT access/api/v1/system/federation/{federation_target_servername}/full_broadcast`

### Files

- `resource_federation_full_broadcast.go`
- `resource_federation_full_broadcast_test.go`
- `CHANGELOG.md`

### Coverage

64/166 (38.6%) → 65/166 (39.2%)

### Checklist

- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] `TestAccFederationFullBroadcast_basic`

---
*Auto-generated by [terraform-provider-sync-agent](https://github.com/jfrog/terraform-provider-sync-agent)*
