### PR TITLE
Add roles attributes to groups resource. Fix ghost drift issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.10 (May 6, 2026).
+## 2.2.10 (May 6, 2026). Tested on Artifactory 7.146.10 with Terraform 1.15.2 and OpenTofu 1.11.6
 
 IMPROVEMENTS:
 * resource/platform_group: Added new role boolean attributes (`reports_manager`, `watch_manager`, `policy_manager`, `policy_viewer`, `manage_resources`, `manage_webhook`), version-gated to Artifactory 7.128.0+. PR: [#316](https://github.com/jfrog/terraform-provider-platform/pull/316). Covers [#182](https://github.com/jfrog/terraform-provider-platform/issues/182), [#184](https://github.com/jfrog/terraform-provider-platform/issues/184)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.10 (May 6, 2026).
+
+IMPROVEMENTS:
+* resource/platform_group: Added new role boolean attributes (`reports_manager`, `watch_manager`, `policy_manager`, `policy_viewer`, `manage_resources`, `manage_webhook`), version-gated to Artifactory 7.128.0+. PR: [#]. Covers [#182](https://github.com/jfrog/terraform-provider-platform/issues/182), [#184](https://github.com/jfrog/terraform-provider-platform/issues/184)
+
+BUG FIXES:
+* resource/platform_group: Fixed ghost drift on `realm` and `realm_attributes`. Fixed empty `description` import drift by rejecting `description = ""` at plan time. Tickets: [#278](https://github.com/jfrog/terraform-provider-platform/issues/287), [#265](https://github.com/jfrog/terraform-provider-platform/issues/265)
+
 ## 2.2.9 (April 21, 2026). Tested on Artifactory 7.146.7 with Terraform 1.14.9 and OpenTofu 1.11.6
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.2.10 (May 6, 2026).
 
 IMPROVEMENTS:
-* resource/platform_group: Added new role boolean attributes (`reports_manager`, `watch_manager`, `policy_manager`, `policy_viewer`, `manage_resources`, `manage_webhook`), version-gated to Artifactory 7.128.0+. PR: [#]. Covers [#182](https://github.com/jfrog/terraform-provider-platform/issues/182), [#184](https://github.com/jfrog/terraform-provider-platform/issues/184)
+* resource/platform_group: Added new role boolean attributes (`reports_manager`, `watch_manager`, `policy_manager`, `policy_viewer`, `manage_resources`, `manage_webhook`), version-gated to Artifactory 7.128.0+. PR: [#316](https://github.com/jfrog/terraform-provider-platform/pull/316). Covers [#182](https://github.com/jfrog/terraform-provider-platform/issues/182), [#184](https://github.com/jfrog/terraform-provider-platform/issues/184)
 
 BUG FIXES:
 * resource/platform_group: Fixed ghost drift on `realm` and `realm_attributes`. Fixed empty `description` import drift by rejecting `description = ""` at plan time. Tickets: [#278](https://github.com/jfrog/terraform-provider-platform/issues/287), [#265](https://github.com/jfrog/terraform-provider-platform/issues/265)

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -36,10 +36,16 @@ resource "platform_group" "my-group" {
 
 - `admin_privileges` (Boolean) Any users added to this group will automatically be assigned with admin privileges in the system.
 - `auto_join` (Boolean) When this parameter is set, any new users defined in the system are automatically assigned to this group.
-- `description` (String) A description for the group.
+- `description` (String) A description for the group. Must be non-empty when set; omit the attribute to leave the group with no description. The Access service normalizes empty strings to null on read, so allowing `""` here would cause perpetual plan drift.
 - `external_id` (String) New external group ID used to configure the corresponding group in Azure AD.
+- `manage_resources` (Boolean) Whether group manages resources in the default project. Available from Artifactory 7.128.0.
+- `manage_webhook` (Boolean) Whether group has manage webhook permissions. Available from Artifactory 7.128.0.
 - `members` (Set of String, Deprecated) List of users assigned to the group.
+- `policy_manager` (Boolean) Whether group has policy manager role. The policy manager role implies the policy viewer role on the server side: setting this to `true` together with `policy_viewer = false` is rejected at plan time. Omit `policy_viewer` or set it to `true`. Available from Artifactory 7.128.0.
+- `policy_viewer` (Boolean) Whether group has policy viewer role. Implied by `policy_manager`: when `policy_manager = true`, the server forces this attribute to `true`. Available from Artifactory 7.128.0.
+- `reports_manager` (Boolean) Whether group has reports manager role. Available from Artifactory 7.128.0.
 - `use_group_members_resource` (Boolean) When set to `true`, this resource will ignore the `members` attributes and allow memberships to be managed by `platform_group_members` resource instead. Default value is `true`.
+- `watch_manager` (Boolean) Whether group has watch manager role. Available from Artifactory 7.128.0.
 
 ### Read-Only
 
@@ -53,4 +59,3 @@ Import is supported using the following syntax:
 ```sh
 terraform import platform_group.my-group my-group
 ```
-

--- a/pkg/platform/resource_group.go
+++ b/pkg/platform/resource_group.go
@@ -16,6 +16,7 @@ package platform
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -24,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -36,6 +38,9 @@ import (
 )
 
 var _ resource.Resource = (*groupResource)(nil)
+var _ resource.ResourceWithValidateConfig = (*groupResource)(nil)
+
+const groupRolesArtifactoryVersion = "7.128.0"
 
 type groupResource struct {
 	util.JFrogResource
@@ -70,7 +75,10 @@ var groupSchemaV0 = schema.Schema{
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},
-			MarkdownDescription: "A description for the group.",
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+			},
+			MarkdownDescription: "A description for the group. Must be non-empty when set; omit the attribute to leave the group with no description. The Access service normalizes empty strings to null on read, so allowing `\"\"` here would cause perpetual plan drift.",
 		},
 		"external_id": schema.StringAttribute{
 			Optional: true,
@@ -105,11 +113,17 @@ var groupSchemaV0 = schema.Schema{
 			MarkdownDescription: "List of users assigned to the group.",
 		},
 		"realm": schema.StringAttribute{
-			Computed:            true,
+			Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 			MarkdownDescription: "The realm for the group.",
 		},
 		"realm_attributes": schema.StringAttribute{
-			Computed:            true,
+			Computed: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 			MarkdownDescription: "The realm for the group.",
 		},
 	},
@@ -136,6 +150,54 @@ var groupSchemaV1 = schema.Schema{
 				Default:             booldefault.StaticBool(true),
 				MarkdownDescription: "When set to `true`, this resource will ignore the `members` attributes and allow memberships to be managed by `platform_group_members` resource instead. Default value is `true`.",
 			},
+			"reports_manager": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+				MarkdownDescription: "Whether group has reports manager role. Available from Artifactory 7.128.0.",
+			},
+			"watch_manager": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+				MarkdownDescription: "Whether group has watch manager role. Available from Artifactory 7.128.0.",
+			},
+			"policy_manager": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+				MarkdownDescription: "Whether group has policy manager role. The policy manager role implies the policy viewer role on the server side: setting this to `true` together with `policy_viewer = false` is rejected at plan time. Omit `policy_viewer` or set it to `true`. Available from Artifactory 7.128.0.",
+			},
+			"policy_viewer": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+				MarkdownDescription: "Whether group has policy viewer role. Implied by `policy_manager`: when `policy_manager = true`, the server forces this attribute to `true`. Available from Artifactory 7.128.0.",
+			},
+			"manage_resources": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+				MarkdownDescription: "Whether group manages resources in the default project. Available from Artifactory 7.128.0.",
+			},
+			"manage_webhook": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+				MarkdownDescription: "Whether group has manage webhook permissions. Available from Artifactory 7.128.0.",
+			},
 		},
 	),
 	MarkdownDescription: groupSchemaV0.MarkdownDescription,
@@ -143,6 +205,69 @@ var groupSchemaV1 = schema.Schema{
 
 func (r *groupResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = groupSchemaV1
+}
+
+// ValidateConfig overrides the embedded JFrogResource.ValidateConfig to
+// enforce two cross-field rules at plan time:
+//  1. The policy_manager role implies policy_viewer on the server side, so the
+//     combination policy_manager=true + policy_viewer=false would be silently
+//     coerced by the API and surface as "Provider produced inconsistent result
+//     after apply". Reject it up front.
+//  2. The role boolean fields were introduced in Artifactory 7.128.0; reject
+//     configurations that set any of them against an older server. The
+//     resource as a whole still works against the base ValidArtifactoryVersion
+//     (7.49.3) when these fields are omitted.
+func (r *groupResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	r.JFrogResource.ValidateConfig(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data groupResourceModelV1
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Rule 1: policy_manager implies policy_viewer.
+	if data.PolicyManager.ValueBool() &&
+		!data.PolicyViewer.IsNull() && !data.PolicyViewer.IsUnknown() &&
+		!data.PolicyViewer.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("policy_viewer"),
+			"Invalid Attribute Combination",
+			"policy_viewer can not be set to false when policy_manager is true; the policy manager role implies the policy viewer role.",
+		)
+	}
+
+	// Rule 2: role booleans require Artifactory >= groupRolesArtifactoryVersion.
+	if r.ProviderData == nil || r.ProviderData.ArtifactoryVersion == "" {
+		return
+	}
+	ok, err := util.CheckVersion(r.ProviderData.ArtifactoryVersion, groupRolesArtifactoryVersion)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to verify Artifactory version", err.Error())
+		return
+	}
+	if ok {
+		return
+	}
+
+	addIfSet := func(field types.Bool, attr string) {
+		if !field.IsNull() && !field.IsUnknown() {
+			resp.Diagnostics.AddAttributeError(
+				path.Root(attr),
+				"Incompatible Artifactory version",
+				fmt.Sprintf("Attribute %q requires Artifactory %s or later. Detected version: %s.", attr, groupRolesArtifactoryVersion, r.ProviderData.ArtifactoryVersion),
+			)
+		}
+	}
+	addIfSet(data.ReportsManager, "reports_manager")
+	addIfSet(data.WatchManager, "watch_manager")
+	addIfSet(data.PolicyManager, "policy_manager")
+	addIfSet(data.PolicyViewer, "policy_viewer")
+	addIfSet(data.ManageResources, "manage_resources")
+	addIfSet(data.ManageWebhook, "manage_webhook")
 }
 
 type groupResourceModelV0 struct {
@@ -159,6 +284,12 @@ type groupResourceModelV0 struct {
 type groupResourceModelV1 struct {
 	groupResourceModelV0
 	UseGroupMembersResource types.Bool `tfsdk:"use_group_members_resource"`
+	ReportsManager          types.Bool `tfsdk:"reports_manager"`
+	WatchManager            types.Bool `tfsdk:"watch_manager"`
+	PolicyManager           types.Bool `tfsdk:"policy_manager"`
+	PolicyViewer            types.Bool `tfsdk:"policy_viewer"`
+	ManageResources         types.Bool `tfsdk:"manage_resources"`
+	ManageWebhook           types.Bool `tfsdk:"manage_webhook"`
 }
 
 func (r *groupResourceModelV1) toAPIModel(ctx context.Context, apiModel *groupAPIModel) (ds diag.Diagnostics) {
@@ -179,6 +310,12 @@ func (r *groupResourceModelV1) toAPIModel(ctx context.Context, apiModel *groupAP
 		AutoJoin:        r.AutoJoin.ValueBoolPointer(),
 		AdminPrivileges: r.AdminPrivileges.ValueBoolPointer(),
 		Members:         members,
+		ReportsManager:  r.ReportsManager.ValueBoolPointer(),
+		WatchManager:    r.WatchManager.ValueBoolPointer(),
+		PolicyManager:   r.PolicyManager.ValueBoolPointer(),
+		PolicyViewer:    r.PolicyViewer.ValueBoolPointer(),
+		ManageResources: r.ManageResources.ValueBoolPointer(),
+		ManageWebhook:   r.ManageWebhook.ValueBoolPointer(),
 	}
 
 	return nil
@@ -194,6 +331,12 @@ func (r *groupResourceModelV1) fromAPIModel(ctx context.Context, apiModel groupA
 	r.AdminPrivileges = types.BoolPointerValue(apiModel.AdminPrivileges)
 	r.Realm = types.StringPointerValue(apiModel.Realm)
 	r.RealmAttributes = types.StringPointerValue(apiModel.RealmAttributes)
+	r.ReportsManager = types.BoolPointerValue(apiModel.ReportsManager)
+	r.WatchManager = types.BoolPointerValue(apiModel.WatchManager)
+	r.PolicyManager = types.BoolPointerValue(apiModel.PolicyManager)
+	r.PolicyViewer = types.BoolPointerValue(apiModel.PolicyViewer)
+	r.ManageResources = types.BoolPointerValue(apiModel.ManageResources)
+	r.ManageWebhook = types.BoolPointerValue(apiModel.ManageWebhook)
 
 	if !r.UseGroupMembersResource.ValueBool() {
 		if r.Members.IsUnknown() {
@@ -247,6 +390,13 @@ type groupAPIModel struct {
 	Members         []string `json:"members,omitempty"`          // only for create
 	Realm           *string  `json:"realm,omitempty"`            // read only
 	RealmAttributes *string  `json:"realm_attributes,omitempty"` // read only
+	// Available from Artifactory 7.128.0
+	ReportsManager  *bool `json:"reports_manager,omitempty"`
+	WatchManager    *bool `json:"watch_manager,omitempty"`
+	PolicyManager   *bool `json:"policy_manager,omitempty"`
+	PolicyViewer    *bool `json:"policy_viewer,omitempty"`
+	ManageResources *bool `json:"manage_resources,omitempty"`
+	ManageWebhook   *bool `json:"manage_webhook,omitempty"`
 }
 
 type groupMembersRequestAPIModel struct {
@@ -294,6 +444,19 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	plan.Realm = types.StringPointerValue(newGroup.Realm)
 	plan.RealmAttributes = types.StringPointerValue(newGroup.RealmAttributes)
+
+	// The role booleans are Optional+Computed (no Default), so when the user
+	// omits them in HCL the planned value is unknown. We must resolve them to
+	// known values from the POST response before saving state, otherwise
+	// Terraform errors with "All values must be known after apply". On older
+	// Artifactory (< 7.128.0) the response omits these fields and the
+	// pointers are nil, which BoolPointerValue maps to null - still known.
+	plan.ReportsManager = types.BoolPointerValue(newGroup.ReportsManager)
+	plan.WatchManager = types.BoolPointerValue(newGroup.WatchManager)
+	plan.PolicyManager = types.BoolPointerValue(newGroup.PolicyManager)
+	plan.PolicyViewer = types.BoolPointerValue(newGroup.PolicyViewer)
+	plan.ManageResources = types.BoolPointerValue(newGroup.ManageResources)
+	plan.ManageWebhook = types.BoolPointerValue(newGroup.ManageWebhook)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/pkg/platform/resource_group_test.go
+++ b/pkg/platform/resource_group_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func TestAccGroup_full(t *testing.T) {
+	skipIfArtifactoryVersionBefore(t, "7.128.0")
+
 	_, fqrn, groupName := testutil.MkNames("test-group", "platform_group")
 
 	temp := `
@@ -38,21 +40,43 @@ func TestAccGroup_full(t *testing.T) {
 			admin_privileges           = false
 			use_group_members_resource = false
 			members                    = {{ .members }}
+			reports_manager            = {{ .reportsManager }}
+			watch_manager              = {{ .watchManager }}
+			policy_manager             = {{ .policyManager }}
+			policy_viewer              = {{ .policyViewer }}
+			manage_resources           = {{ .manageResources }}
+			manage_webhook             = {{ .manageWebhook }}
 		}
 	`
 
+	// The Access API treats policy_manager as implying policy_viewer (a
+	// manager is also a viewer). Keep the test data consistent with that
+	// hierarchy: when policy_manager = true, policy_viewer must also be true,
+	// otherwise the BoolImplies validator fires at plan time.
 	testData := map[string]string{
-		"groupName": groupName,
-		"autoJoin":  fmt.Sprintf("%t", testutil.RandBool()),
-		"members":   "[\"anonymous\", \"admin\"]",
+		"groupName":       groupName,
+		"autoJoin":        fmt.Sprintf("%t", testutil.RandBool()),
+		"members":         "[\"anonymous\", \"admin\"]",
+		"reportsManager":  "true",
+		"watchManager":    "false",
+		"policyManager":   "true",
+		"policyViewer":    "true",
+		"manageResources": "true",
+		"manageWebhook":   "false",
 	}
 
 	config := util.ExecuteTemplate(groupName, temp, testData)
 
 	updatedTestData := map[string]string{
-		"groupName": groupName,
-		"autoJoin":  fmt.Sprintf("%t", testutil.RandBool()),
-		"members":   "[\"admin\"]",
+		"groupName":       groupName,
+		"autoJoin":        fmt.Sprintf("%t", testutil.RandBool()),
+		"members":         "[\"admin\"]",
+		"reportsManager":  "false",
+		"watchManager":    "true",
+		"policyManager":   "false",
+		"policyViewer":    "true",
+		"manageResources": "false",
+		"manageWebhook":   "true",
 	}
 
 	updatedConfig := util.ExecuteTemplate(groupName, temp, updatedTestData)
@@ -62,9 +86,26 @@ func TestAccGroup_full(t *testing.T) {
 		"autoJoin":        fmt.Sprintf("%t", testutil.RandBool()),
 		"adminPrivileges": fmt.Sprintf("%t", testutil.RandBool()),
 		"members":         "[\"anonymous\"]",
+		"reportsManager":  "true",
+		"watchManager":    "true",
+		"policyManager":   "false",
+		"policyViewer":    "false",
+		"manageResources": "true",
+		"manageWebhook":   "true",
 	}
 
 	updated2Config := util.ExecuteTemplate(groupName, temp, updated2TestData)
+
+	rolesCheck := func(td map[string]string) resource.TestCheckFunc {
+		return resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(fqrn, "reports_manager", td["reportsManager"]),
+			resource.TestCheckResourceAttr(fqrn, "watch_manager", td["watchManager"]),
+			resource.TestCheckResourceAttr(fqrn, "policy_manager", td["policyManager"]),
+			resource.TestCheckResourceAttr(fqrn, "policy_viewer", td["policyViewer"]),
+			resource.TestCheckResourceAttr(fqrn, "manage_resources", td["manageResources"]),
+			resource.TestCheckResourceAttr(fqrn, "manage_webhook", td["manageWebhook"]),
+		)
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -83,7 +124,19 @@ func TestAccGroup_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "members.#", "2"),
 					resource.TestCheckResourceAttr(fqrn, "members.0", "admin"),
 					resource.TestCheckResourceAttr(fqrn, "members.1", "anonymous"),
+					rolesCheck(testData),
 				),
+			},
+			{
+				// Re-applying the same config must produce no diff. This guards
+				// against drift on Computed-only attrs like realm/realm_attributes
+				// and the new role booleans.
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 			{
 				Config: updatedConfig,
@@ -97,6 +150,7 @@ func TestAccGroup_full(t *testing.T) {
 					resource.TestCheckNoResourceAttr(fqrn, "realm_attributes"),
 					resource.TestCheckResourceAttr(fqrn, "members.#", "1"),
 					resource.TestCheckResourceAttr(fqrn, "members.0", "admin"),
+					rolesCheck(updatedTestData),
 				),
 			},
 			{
@@ -111,6 +165,7 @@ func TestAccGroup_full(t *testing.T) {
 					resource.TestCheckNoResourceAttr(fqrn, "realm_attributes"),
 					resource.TestCheckResourceAttr(fqrn, "members.#", "1"),
 					resource.TestCheckResourceAttr(fqrn, "members.0", "anonymous"),
+					rolesCheck(updated2TestData),
 				),
 			},
 			{
@@ -290,6 +345,112 @@ func TestAccGroup_auto_join_conflict(t *testing.T) {
 			{
 				Config:      config,
 				ExpectError: regexp.MustCompile(".*can not be set to.*"),
+			},
+		},
+	})
+}
+
+// TestAccGroup_policy_manager_implies_viewer asserts that the BoolImplies
+// validator on policy_manager rejects the only invalid combination at plan
+// time: policy_manager = true together with policy_viewer = false. The Access
+// API would otherwise silently coerce policy_viewer back to true, surfacing as
+// a "Provider produced inconsistent result after apply" error.
+func TestAccGroup_policy_manager_implies_viewer(t *testing.T) {
+	skipIfArtifactoryVersionBefore(t, "7.128.0")
+
+	_, _, groupName := testutil.MkNames("test-group", "platform_group")
+	temp := `
+		resource "platform_group" "{{ .groupName }}" {
+			name           = "{{ .groupName }}"
+			description    = "Test group"
+			policy_manager = true
+			policy_viewer  = false
+		}
+	`
+
+	config := util.ExecuteTemplate(groupName, temp, map[string]string{"groupName": groupName})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(".*can not be set to.*"),
+			},
+		},
+	})
+}
+
+// TestAccGroup_description_empty verifies that the validator on the
+// `description` attribute rejects empty strings at plan time. The Access
+// service normalizes empty descriptions to null on read, so allowing `""`
+// would cause perpetual plan drift after import / first apply (see issue #265).
+func TestAccGroup_description_empty(t *testing.T) {
+	_, _, groupName := testutil.MkNames("test-group", "platform_group")
+
+	temp := `
+		resource "platform_group" "{{ .groupName }}" {
+			name        = "{{ .groupName }}"
+			description = ""
+		}
+	`
+	config := util.ExecuteTemplate(groupName, temp, map[string]string{"groupName": groupName})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?i)attribute description string length must be at least 1`),
+			},
+		},
+	})
+}
+
+// TestAccGroup_import_no_description guards against the regression in issue
+// #265: a group whose description was never set on the server (the GET
+// response omits the field entirely) must be importable, must not show drift
+// on subsequent plans, and must round-trip through ImportStateVerify.
+func TestAccGroup_import_no_description(t *testing.T) {
+	_, fqrn, groupName := testutil.MkNames("test-group", "platform_group")
+
+	temp := `
+		resource "platform_group" "{{ .groupName }}" {
+			name = "{{ .groupName }}"
+		}
+	`
+	config := util.ExecuteTemplate(groupName, temp, map[string]string{"groupName": groupName})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "name", groupName),
+					resource.TestCheckNoResourceAttr(fqrn, "description"),
+				),
+			},
+			{
+				// Re-applying the same config must produce no diff, even
+				// though the GET response omits the description field.
+				Config: config,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        groupName,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+				ImportStateVerifyIgnore:              []string{"use_group_members_resource"},
 			},
 		},
 	})

--- a/pkg/platform/util_test.go
+++ b/pkg/platform/util_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/jfrog/terraform-provider-platform/v2/pkg/platform"
 	"github.com/jfrog/terraform-provider-shared/client"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 // TestProvider PreCheck(t) must be called before using this provider instance.
@@ -94,5 +95,24 @@ func testAccProviders() map[string]func() (tfprotov6.ProviderServer, error) {
 
 	return map[string]func() (tfprotov6.ProviderServer, error){
 		"platform": providerserver.NewProtocol6WithError(TestProvider),
+	}
+}
+
+// skipIfArtifactoryVersionBefore skips the current test when the Artifactory
+// instance under test is older than minVersion. The detected server version is
+// included in the skip message to make CI logs self-explanatory.
+func skipIfArtifactoryVersionBefore(t *testing.T, minVersion string) {
+	t.Helper()
+	restyClient := getTestResty(t)
+	version, err := util.GetArtifactoryVersion(restyClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid, err := util.CheckVersion(version, minVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !valid {
+		t.Skipf("Artifactory version %s is earlier than %s", version, minVersion)
 	}
 }


### PR DESCRIPTION
- Add `reports_manager`, `watch_manager`, `policy_manager`, `policy_viewer`,
`manage_resources`, `manage_webhook` (Artifactory 7.128.0+), gated via
ValidateConfig with a plan-time rule that policy_manager implies
policy_viewer. 
- Fix perpetual drift on realm/realm_attributes and on
empty description by adding UseStateForUnknown and rejecting
`description = ""` at plan time.

fixes:
- https://github.com/jfrog/terraform-provider-platform/issues/182
- https://github.com/jfrog/terraform-provider-platform/issues/184
- https://github.com/jfrog/terraform-provider-platform/issues/287
- https://github.com/jfrog/terraform-provider-platform/issues/265