### PR TITLE
handle 404 gracefully in platform_lifecycle Read and fix permission doc examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.11 (May 12, 2025).
+## 2.2.11 (May 12, 2025). Tested on Artifactory 7.146.10 with Terraform 1.15.2 and OpenTofu 1.11.7
 
 IMPROVEMENTS:
 * resource/platform_workers_service: Added support for `SCHEDULED_EVENT` action type [#197](https://github.com/jfrog/terraform-provider-platform/issues/197) PR: [#281](https://github.com/jfrog/terraform-provider-platform/pull/281)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ IMPROVEMENTS:
 * resource/platform_workers_service: Added support for `SCHEDULED_EVENT` action type [#197](https://github.com/jfrog/terraform-provider-platform/issues/197) PR: [#281](https://github.com/jfrog/terraform-provider-platform/pull/281)
 
 BUG FIXES:
+* resource/platform_lifecycle: Fixed `terraform plan` failing with `Lifecycle Not Found` when the project and its lifecycle are deleted via the UI. The provider now correctly removes the resource from Terraform state on HTTP 404, allowing Terraform to plan a recreation instead of erroring.
+* resource/platform_permission: Fixed incorrect example values for wildcard repository targets. Corrected `ALL-LOCAL` → `ANY LOCAL`, `ALL-REMOTE` → `ANY REMOTE`, and `ALL-DISTRIBUTION` → `ANY DISTRIBUTION` in docs and examples.
 * resource/platform_oidc_identity_mapping: Fixed `project_key` being silently ignored. The `project_key` value is now correctly sent as a `?project_key=` query parameter on create, read, update, and delete requests, and is populated back into state from the API response. Previously, all mappings were created as global regardless of `project_key`. Issue: [#311](https://github.com/jfrog/terraform-provider-platform/issues/311) PR: [#317](https://github.com/jfrog/terraform-provider-platform/pull/317)
 
 ## 2.2.10 (May 6, 2026). Tested on Artifactory 7.146.10 with Terraform 1.15.2 and OpenTofu 1.11.6

--- a/docs/resources/permission.md
+++ b/docs/resources/permission.md
@@ -32,15 +32,15 @@ resource "platform_permission" "my-permission" {
         include_patterns = ["**"]
       },
       {
-        name = "ALL-LOCAL"
+        name = "ANY LOCAL"
         include_patterns = ["**", "*.js"]
       },
       {
-        name = "ALL-REMOTE"
+        name = "ANY REMOTE"
         include_patterns = ["**", "*.js"]
       },
       {
-        name = "ALL-DISTRIBUTION"
+        name = "ANY DISTRIBUTION"
         include_patterns = ["**", "*.js"]
       }
     ]

--- a/examples/resources/platform_permission/resource.tf
+++ b/examples/resources/platform_permission/resource.tf
@@ -17,15 +17,15 @@ resource "platform_permission" "my-permission" {
         include_patterns = ["**"]
       },
       {
-        name = "ALL-LOCAL"
+        name = "ANY LOCAL"
         include_patterns = ["**", "*.js"]
       },
       {
-        name = "ALL-REMOTE"
+        name = "ANY REMOTE"
         include_patterns = ["**", "*.js"]
       },
       {
-        name = "ALL-DISTRIBUTION"
+        name = "ANY DISTRIBUTION"
         include_patterns = ["**", "*.js"]
       }
     ]

--- a/pkg/platform/resource_lifecycle.go
+++ b/pkg/platform/resource_lifecycle.go
@@ -407,7 +407,35 @@ func (r *lifecycleResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	resp.Diagnostics.Append(r.readLifecycle(ctx, &state)...)
+	var lifecycle lifecycleAPIModel
+	var apiErrs util.JFrogErrors
+	request := r.ProviderData.Client.R().
+		SetResult(&lifecycle).
+		SetError(&apiErrs)
+
+	if !state.ProjectKey.IsNull() && state.ProjectKey.ValueString() != "" {
+		request = request.SetQueryParam("project_key", state.ProjectKey.ValueString())
+	}
+
+	response, err := request.Get(r.JFrogResource.CollectionEndpoint)
+	if err != nil {
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
+		return
+	}
+
+	// Treat HTTP 404 Not Found status as a signal to recreate resource
+	// and return early
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		utilfw.UnableToRefreshResourceError(resp, apiErrs.String())
+		return
+	}
+
+	resp.Diagnostics.Append(state.fromAPIModel(ctx, lifecycle)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -422,30 +450,14 @@ func (r *lifecycleResource) readLifecycle(ctx context.Context, model *lifecycleR
 		SetResult(&lifecycle).
 		SetError(&apiErrs)
 
-	// Add project_key as query parameter if set
 	if !model.ProjectKey.IsNull() && model.ProjectKey.ValueString() != "" {
 		request = request.SetQueryParam("project_key", model.ProjectKey.ValueString())
 	}
 
 	response, err := request.Get(r.JFrogResource.CollectionEndpoint)
-
 	if err != nil {
 		return diag.Diagnostics{
-			diag.NewErrorDiagnostic(
-				"Unable to Read Lifecycle",
-				err.Error(),
-			),
-		}
-	}
-
-	if response.StatusCode() == http.StatusNotFound {
-		// According to the API, lifecycle must exist - 404 means it truly doesn't exist
-		// This is an error for both global and project lifecycles
-		return diag.Diagnostics{
-			diag.NewErrorDiagnostic(
-				"Lifecycle Not Found",
-				"The lifecycle was not found. Lifecycles are created automatically when stages are added.",
-			),
+			diag.NewErrorDiagnostic("Unable to Read Lifecycle", err.Error()),
 		}
 	}
 
@@ -458,10 +470,7 @@ func (r *lifecycleResource) readLifecycle(ctx context.Context, model *lifecycleR
 			errorMsg = fmt.Sprintf("unexpected status code: %d", response.StatusCode())
 		}
 		return diag.Diagnostics{
-			diag.NewErrorDiagnostic(
-				"Unable to Read Lifecycle",
-				errorMsg,
-			),
+			diag.NewErrorDiagnostic("Unable to Read Lifecycle", errorMsg),
 		}
 	}
 


### PR DESCRIPTION
## Summary

### Bug Fix: `platform_lifecycle` — Lifecycle Not Found on `terraform plan` after UI deletion

When a project and its associated lifecycle were deleted via the JFrog UI, `terraform plan` failed with a hard `Lifecycle Not Found` error instead of planning a recreation. This forced users to manually run `terraform state rm` to unblock themselves.

**Root cause:** The `Read` function in `resource_lifecycle.go` returned a hard error on HTTP 404. It should instead remove the resource from Terraform state, signalling Terraform to plan a recreation — which is the standard pattern used by all other resources in this provider.

**Fix:** Updated the `Read` function to call `resp.State.RemoveResource(ctx)` on HTTP 404, inline with the request — matching the pattern used by `platform_lifecycle_stage`, `platform_global_role`, and other resources.

### Docs Fix: `platform_permission` — Incorrect wildcard repository target names in examples

Examples in `docs/resources/permission.md` and `examples/resources/platform_permission/resource.tf` used incorrect values (`ALL-LOCAL`, `ALL-REMOTE`, `ALL-DISTRIBUTION`) for wildcard repository targets. The correct values are `ANY LOCAL`, `ANY REMOTE`, and `ANY DISTRIBUTION`.

Reported by Okta.

---

## Changes

| File | Change |
|---|---|
| `pkg/platform/resource_lifecycle.go` | `Read` now calls `resp.State.RemoveResource(ctx)` on HTTP 404 instead of returning a hard error |
| `docs/resources/permission.md` | Fixed `ALL-LOCAL` → `ANY LOCAL`, `ALL-REMOTE` → `ANY REMOTE`, `ALL-DISTRIBUTION` → `ANY DISTRIBUTION` |
| `examples/resources/platform_permission/resource.tf` | Same corrections as above |
| `CHANGELOG.md` | Updated for both fixes |
| `sample.tf` | Added project, lifecycle stages, and lifecycle example blocks |

---

## Steps to Reproduce (lifecycle bug)

1. Create a project with `platform_lifecycle` via Terraform
2. Delete the project via the JFrog UI
3. Run `terraform plan` → previously failed with `Lifecycle Not Found`
4. After fix → `terraform plan` shows `Plan: N to add` with no error

## Test Plan

- [x] Verify `terraform plan` after UI deletion shows recreation plan, no error
- [x] Verify `terraform apply` successfully recreates the lifecycle
- [x] Verify existing lifecycle resources unaffected when not deleted externally
- [x] Verify `ANY LOCAL`, `ANY REMOTE`, `ANY DISTRIBUTION` work correctly in `platform_permission`
