### PR TITLE
fix(permission): stabilize Read order to eliminate spurious no-op diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.2.12 (May 13, 2026).
+
+BUG FIXES:
+* resource/platform_permission: Fixed spurious no-op diff where `targets`, `actions.users`, and `actions.groups` elements would swap positions on every `terraform plan` even when no real change occurred. The provider was iterating Go maps non-deterministically when building the state slice; the slice is now sorted by `name` before being wrapped in a `types.Set`.
+
 ## 2.2.11 (May 12, 2025).
 
 IMPROVEMENTS:

--- a/pkg/platform/resource_permission.go
+++ b/pkg/platform/resource_permission.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
@@ -676,6 +677,29 @@ var resourceResourceModelAttributeTypes map[string]attr.Type = map[string]attr.T
 	},
 }
 
+// sortAttrValuesByName sorts a slice of `attr.Value` (each expected to be a
+// `types.Object` containing a `name` string attribute) in ascending order by
+// that name. This is used to give a deterministic order to slices that come
+// from non-deterministic Go map iteration before they are wrapped in a
+// `types.Set`. Even though the framework treats them as sets semantically,
+// ordering instability in the intermediate slice surfaces as a no-op
+// positional diff in `terraform plan`.
+func sortAttrValuesByName(values []attr.Value) {
+	sort.SliceStable(values, func(i, j int) bool {
+		oi, iOK := values[i].(types.Object)
+		oj, jOK := values[j].(types.Object)
+		if !iOK || !jOK {
+			return false
+		}
+		ni, niOK := oi.Attributes()["name"].(types.String)
+		nj, njOK := oj.Attributes()["name"].(types.String)
+		if !niOK || !njOK {
+			return false
+		}
+		return ni.ValueString() < nj.ValueString()
+	})
+}
+
 func (r *permissionResourceModel) fromUsersGroupsAPIModel(ctx context.Context, usersGroups map[string][]string) (set types.Set, ds diag.Diagnostics) {
 	userGroupSet := lo.MapToSlice(
 		usersGroups,
@@ -706,6 +730,12 @@ func (r *permissionResourceModel) fromUsersGroupsAPIModel(ctx context.Context, u
 			return t
 		},
 	)
+
+	// Sort by `name` so the slice order is deterministic. Without this,
+	// Go's randomized map iteration causes a different element order on
+	// each Read, which surfaces as a no-op positional diff in
+	// `terraform plan`.
+	sortAttrValuesByName(userGroupSet)
 
 	ugs, d := types.SetValue(
 		usersGroupsResourceModelAttributeTypes,
@@ -789,6 +819,12 @@ func (r *permissionResourceModel) fromResourceAPIModel(ctx context.Context, reso
 				return t
 			},
 		)
+
+		// Sort by `name` so the slice order is deterministic. Without
+		// this, Go's randomized map iteration causes a different
+		// element order on each Read, which surfaces as a no-op
+		// positional diff in `terraform plan`.
+		sortAttrValuesByName(targetsSlice)
 
 		targetsSet, d := types.SetValue(
 			targetsResourceModelAttributeTypes,


### PR DESCRIPTION
A permission with multiple `targets` (or `actions.users` / `actions.groups`) shows a no-op diff on every `terraform plan` — items swap positions even though nothing actually changed:

```
targets: [
  ~ [0]: { ~ name: "ANY REMOTE" => "my-repo-local" }
  ~ [1]: { ~ name: "my-repo-local" => "ANY REMOTE" }
]
```

The cause is in `fromResourceAPIModel` and `fromUsersGroupsAPIModel`: the API response is unmarshaled into a Go `map`, then turned into a slice with `lo.MapToSlice` before being wrapped in a `types.Set`. Go map iteration is randomized, so the intermediate slice comes out in a different order on every Read, and that order leaks into state.

Fix: sort the slice by `name` before calling `types.SetValue`. Added a small `sortAttrValuesByName` helper and call it in both spots.
