### PR TITLE
add azure_app_id attribute to platform_oidc_configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 2.2.11 (May 12, 2025).
 
 IMPROVEMENTS:
-* resource/platform_workers_service: Added support for `SCHEDULED_EVENT` action type [#197](https://github.com/jfrog/terraform-provider-platform/issues/197) PR: [#281](https://github.com/jfrog/terraform-provider-platform/pull/281)
+* resource/platform_oidc_configuration: Added `azure_app_id` attribute (Optional, only valid when `provider_type = Azure`). Issue: [#312](https://github.com/jfrog/terraform-provider-platform/issues/312)
+* resource/platform_workers_service: Added support for `SCHEDULED_EVENT` action type. Issue: [#197](https://github.com/jfrog/terraform-provider-platform/issues/197) PR: [#281](https://github.com/jfrog/terraform-provider-platform/pull/281)
 
 BUG FIXES:
 * resource/platform_oidc_identity_mapping: Fixed `project_key` being silently ignored. The `project_key` value is now correctly sent as a `?project_key=` query parameter on create, read, update, and delete requests, and is populated back into state from the API response. Previously, all mappings were created as global regardless of `project_key`. Issue: [#311](https://github.com/jfrog/terraform-provider-platform/issues/311) PR: [#317](https://github.com/jfrog/terraform-provider-platform/pull/317)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.11 (May 12, 2025).
+## 2.2.11 (May 12, 2025). Tested on Artifactory 7.146.10 with Terraform 1.15.3 and OpenTofu 1.11.7
 
 IMPROVEMENTS:
 * resource/platform_oidc_configuration: Added `azure_app_id` attribute (Optional, only valid when `provider_type = Azure`). Issue: [#312](https://github.com/jfrog/terraform-provider-platform/issues/312)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.11 (May 12, 2025). 
+## 2.2.11 (May 12, 2025). Tested on Artifactory 7.146.10 with Terraform 1.15.3 and OpenTofu 1.11.7
 
 IMPROVEMENTS:
 * resource/platform_oidc_configuration: Added `azure_app_id` attribute (Optional, only valid when `provider_type = Azure`). Issue: [#312](https://github.com/jfrog/terraform-provider-platform/issues/312)

--- a/docs/resources/oidc_configuration.md
+++ b/docs/resources/oidc_configuration.md
@@ -41,11 +41,12 @@ resource "platform_oidc_configuration" "my-generic-oidc-configuration" {
 
 
 resource "platform_oidc_configuration" "my-azure-oidc-configuration" {
-  name              = "{{ .name }}"
+  name              = "my-azure-oidc-configuration"
   description       = "My Azure OIDC configuration"
   issuer_url        = "https://sts.windows.net/your-tenant-id/"
   provider_type     = "Azure"
   audience          = "azure-audience"
+  azure_app_id      = "00000000-0000-0000-0000-000000000000"
   use_default_proxy = true
 }
 ```
@@ -62,6 +63,7 @@ resource "platform_oidc_configuration" "my-azure-oidc-configuration" {
 ### Optional
 
 - `audience` (String) Informational field that you can use to include details of the audience that uses the OIDC configuration.
+- `azure_app_id` (String) Azure Application ID. Only applicable when `provider_type` is `Azure`.
 - `description` (String) Description of the OIDC provider
 - `enable_permissive_configuration` (Boolean) Only settable when `provider_type` is GitHub or GitHubEnterprise. When set, Allows authentication without any restrictions. For security best practices, it is recommended to add restrictions to limit access and enforce stricter controls. Use with caution, as this may grant broader access.
 - `organization` (String) This field is mandatory, when `provider_type` is GitHub or GitHubEnterprise. Informational field that you can use to include details of the organization that uses the OIDC configuration.

--- a/examples/resources/platform_oidc_configuration/resource.tf
+++ b/examples/resources/platform_oidc_configuration/resource.tf
@@ -26,10 +26,11 @@ resource "platform_oidc_configuration" "my-generic-oidc-configuration" {
 
 
 resource "platform_oidc_configuration" "my-azure-oidc-configuration" {
-  name              = "{{ .name }}"
+  name              = "my-azure-oidc-configuration"
   description       = "My Azure OIDC configuration"
   issuer_url        = "https://sts.windows.net/your-tenant-id/"
   provider_type     = "Azure"
   audience          = "azure-audience"
+  azure_app_id      = "00000000-0000-0000-0000-000000000000"
   use_default_proxy = true
 }

--- a/pkg/platform/resource_oidc_configuration.go
+++ b/pkg/platform/resource_oidc_configuration.go
@@ -127,6 +127,10 @@ func (r *oidcConfigurationResource) Schema(ctx context.Context, req resource.Sch
 				},
 				Description: "If set, this Identity Configuration will be available in the scope of the given project (editable by platform admin and project admin). If not set, this Identity Configuration will be global and only editable by platform admin. Once set, the projectKey cannot be changed.",
 			},
+			"azure_app_id": schema.StringAttribute{
+				Optional:    true,
+				Description: fmt.Sprintf("Azure Application ID. Only applicable when `provider_type` is `%s`.", azureProviderType),
+			},
 			"use_default_proxy": schema.BoolAttribute{
 				Optional:            true,
 				Computed:            true,
@@ -205,6 +209,14 @@ func (r oidcConfigurationResource) ValidateConfig(ctx context.Context, req resou
 			}
 		}
 	}
+
+	if !data.AzureAppId.IsNull() && data.ProviderType.ValueString() != azureProviderType {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("azure_app_id"),
+			"Invalid Attribute Configuration",
+			fmt.Sprintf("azure_app_id is only applicable when provider_type is set to '%s'.", azureProviderType),
+		)
+	}
 }
 
 type oidcConfigurationResourceModel struct {
@@ -215,6 +227,7 @@ type oidcConfigurationResourceModel struct {
 	Audience                      types.String `tfsdk:"audience"`
 	Organization                  types.String `tfsdk:"organization"`
 	ProjectKey                    types.String `tfsdk:"project_key"`
+	AzureAppId                    types.String `tfsdk:"azure_app_id"`
 	UseDefaultProxy               types.Bool   `tfsdk:"use_default_proxy"`
 	EnablePermissiveConfiguration types.Bool   `tfsdk:"enable_permissive_configuration"`
 }
@@ -227,6 +240,7 @@ type oidcConfigurationAPIModel struct {
 	Audience                      string `json:"audience,omitempty"`
 	Organization                  string `json:"organization"`
 	ProjectKey                    string `json:"project_key,omitempty"`
+	AzureAppId                    string `json:"azure_app_id,omitempty"`
 	UseDefaultProxy               bool   `json:"use_default_proxy"`
 	EnablePermissiveConfiguration bool   `json:"enable_permissive_configuration,omitempty"`
 }
@@ -256,6 +270,10 @@ func (r *oidcConfigurationResource) Create(ctx context.Context, req resource.Cre
 		Description:     plan.Description.ValueString(),
 		ProjectKey:      plan.ProjectKey.ValueString(),
 		UseDefaultProxy: plan.UseDefaultProxy.ValueBool(),
+	}
+
+	if plan.ProviderType.ValueString() == azureProviderType {
+		oidcConfig.AzureAppId = plan.AzureAppId.ValueString()
 	}
 
 	// Access version 7.138.0 or later is required for the `organization` attribute when `provider_type` is set to `GitHub`
@@ -392,6 +410,10 @@ func (r *oidcConfigurationResource) Read(ctx context.Context, req resource.ReadR
 		state.ProviderType = types.StringValue(oidcConfig.ProviderType)
 	}
 
+	if len(oidcConfig.AzureAppId) > 0 {
+		state.AzureAppId = types.StringValue(oidcConfig.AzureAppId)
+	}
+
 	state.UseDefaultProxy = types.BoolValue(oidcConfig.UseDefaultProxy)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -422,6 +444,10 @@ func (r *oidcConfigurationResource) Update(ctx context.Context, req resource.Upd
 		Description:     plan.Description.ValueString(),
 		ProjectKey:      plan.ProjectKey.ValueString(),
 		UseDefaultProxy: plan.UseDefaultProxy.ValueBool(),
+	}
+
+	if plan.ProviderType.ValueString() == azureProviderType {
+		oidcConfig.AzureAppId = plan.AzureAppId.ValueString()
 	}
 
 	// Access version 7.138.0 or later is required for the `organization` attribute when `provider_type` is set to `GitHub`

--- a/pkg/platform/resource_oidc_configuration_test.go
+++ b/pkg/platform/resource_oidc_configuration_test.go
@@ -452,6 +452,7 @@ resource "platform_oidc_configuration" "{{ .name }}" {
   issuer_url        = "{{ .issuerURL }}"
   provider_type     = "{{ .providerType }}"
   audience          = "{{ .audience }}"
+  azure_app_id      = "{{ .azureAppId }}"
   use_default_proxy = true
 }`
 
@@ -460,6 +461,7 @@ resource "platform_oidc_configuration" "{{ .name }}" {
 		"issuerURL":    "https://sts.windows.net/your-tenant-id/",
 		"providerType": "Azure",
 		"audience":     "azure-audience",
+		"azureAppId":   "test-azure-app-id",
 	}
 	updatedConfig := util.ExecuteTemplate(configName, updatedTemp, updatedTestData)
 
@@ -490,6 +492,7 @@ resource "platform_oidc_configuration" "{{ .name }}" {
 					resource.TestCheckResourceAttr(fqrn, "issuer_url", updatedTestData["issuerURL"]),
 					resource.TestCheckResourceAttr(fqrn, "provider_type", updatedTestData["providerType"]),
 					resource.TestCheckResourceAttr(fqrn, "audience", updatedTestData["audience"]),
+					resource.TestCheckResourceAttr(fqrn, "azure_app_id", updatedTestData["azureAppId"]),
 					resource.TestCheckResourceAttr(fqrn, "use_default_proxy", "true"),
 				),
 			},


### PR DESCRIPTION
## Summary

Adds `azure_app_id` (Optional) attribute to the `platform_oidc_configuration` resource. The attribute is only valid when `provider_type = "Azure"` — a `ValidateConfig` check rejects it for any other provider type.

Closes #312

## Changes

- **`resource_oidc_configuration.go`**: Added `azure_app_id` schema attribute, `ValidateConfig` enforcement, struct fields in both the Terraform model and API model, and wiring in `Create`, `Read`, and `Update`.
- **`resource_oidc_configuration_test.go`**: Extended the Azure acceptance test to set `azure_app_id` and assert its value after apply.
- **`docs/resources/oidc_configuration.md`**: Added `azure_app_id` to the Azure example and the Optional schema reference.
- **`examples/resources/platform_oidc_configuration/resource.tf`**: Added `azure_app_id` to the Azure example block.
- **`CHANGELOG.md`**: Added entry under 2.2.11 IMPROVEMENTS.

## Usage

```hcl
resource "platform_oidc_configuration" "azure" {
  name          = "my-azure-oidc"
  issuer_url    = "https://sts.windows.net/<tenant-id>/"
  provider_type = "Azure"
  azure_app_id  = "<azure-application-id>"
}
```

## Testing

- [ ] `TestAccOidcConfigurationResource_Azure` passes with `azure_app_id` set and verified in state
- [ ] Setting `azure_app_id` with a non-Azure `provider_type` returns a clear validation error
