### PR TITLE
add token_issuer, enforce provider_type immutability and enable_permissive_configuration validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 IMPROVEMENTS:
 * resource/platform_oidc_configuration: Added `azure_app_id` attribute (Optional, only valid when `provider_type = Azure`). Issue: [#312](https://github.com/jfrog/terraform-provider-platform/issues/312)
+* resource/platform_oidc_configuration: Added `token_issuer` attribute (Optional/Computed). Only applicable when `provider_type` is `generic` or `Azure`; not allowed for `GitHub` or `GitHubEnterprise`. Added `RequiresReplace` to `provider_type` to prevent invalid in-place type changes.
 * resource/platform_workers_service: Added support for `SCHEDULED_EVENT` action type. Issue: [#197](https://github.com/jfrog/terraform-provider-platform/issues/197) PR: [#281](https://github.com/jfrog/terraform-provider-platform/pull/281)
+
+NOTES:
+* resource/platform_oidc_configuration: `provider_type` now requires resource replacement when changed. Existing resources with an unchanged `provider_type` are unaffected.
+* resource/platform_oidc_configuration: `enable_permissive_configuration` is now validated to only be set when `provider_type` is `GitHub` or `GitHubEnterprise`. Configurations that incorrectly set this attribute on `generic` or `Azure` provider types will fail validation and must remove it before applying.
 
 BUG FIXES:
 * resource/platform_lifecycle: Fixed `terraform plan` failing with `Lifecycle Not Found` when the project and its lifecycle are deleted via the UI. The provider now correctly removes the resource from Terraform state on HTTP 404, allowing Terraform to plan a recreation instead of erroring.

--- a/docs/resources/oidc_configuration.md
+++ b/docs/resources/oidc_configuration.md
@@ -68,6 +68,7 @@ resource "platform_oidc_configuration" "my-azure-oidc-configuration" {
 - `enable_permissive_configuration` (Boolean) Only settable when `provider_type` is GitHub or GitHubEnterprise. When set, Allows authentication without any restrictions. For security best practices, it is recommended to add restrictions to limit access and enforce stricter controls. Use with caution, as this may grant broader access.
 - `organization` (String) This field is mandatory, when `provider_type` is GitHub or GitHubEnterprise. Informational field that you can use to include details of the organization that uses the OIDC configuration.
 - `project_key` (String) If set, this Identity Configuration will be available in the scope of the given project (editable by platform admin and project admin). If not set, this Identity Configuration will be global and only editable by platform admin. Once set, the projectKey cannot be changed.
+- `token_issuer` (String, Optional/Computed) Token issuer URL of the identity provider. Not allowed when `provider_type` is `GitHub` or `GitHubEnterprise`.
 - `use_default_proxy` (Boolean) This enables and disables the default proxy for OIDC integration. If enabled, the OIDC mechanism will utilize the default proxy for all OIDC requests. If disabled, the OIDC mechanism does not use any proxy for all OIDC requests. Before enabling this functionality you must configure the default proxy.
 
 ## Import

--- a/examples/resources/platform_oidc_configuration/resource.tf
+++ b/examples/resources/platform_oidc_configuration/resource.tf
@@ -22,6 +22,7 @@ resource "platform_oidc_configuration" "my-generic-oidc-configuration" {
   issuer_url    = "https://tempurl.org"
   provider_type = "generic"
   audience      = "jfrog-generic"
+  token_issuer  = "https://tempurl.org"
 }
 
 

--- a/pkg/platform/resource_oidc_configuration.go
+++ b/pkg/platform/resource_oidc_configuration.go
@@ -100,6 +100,9 @@ func (r *oidcConfigurationResource) Schema(ctx context.Context, req resource.Sch
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"generic", gitHubProviderType, githubEnterpriseType, azureProviderType}...),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 				MarkdownDescription: fmt.Sprintf("Type of OIDC provider. Can be `generic`, `%s`, `%s` or `%s`.", gitHubProviderType, githubEnterpriseType, azureProviderType),
 			},
 			"audience": schema.StringAttribute{
@@ -126,6 +129,14 @@ func (r *oidcConfigurationResource) Schema(ctx context.Context, req resource.Sch
 					stringplanmodifier.RequiresReplace(),
 				},
 				Description: "If set, this Identity Configuration will be available in the scope of the given project (editable by platform admin and project admin). If not set, this Identity Configuration will be global and only editable by platform admin. Once set, the projectKey cannot be changed.",
+			},
+			"token_issuer": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+				Description: fmt.Sprintf("Token issuer URL of the identity provider. Not allowed when `provider_type` is `%s` or `%s`.", gitHubProviderType, githubEnterpriseType),
 			},
 			"azure_app_id": schema.StringAttribute{
 				Optional:    true,
@@ -217,6 +228,26 @@ func (r oidcConfigurationResource) ValidateConfig(ctx context.Context, req resou
 			fmt.Sprintf("azure_app_id is only applicable when provider_type is set to '%s'.", azureProviderType),
 		)
 	}
+
+	if !data.TokenIssuer.IsNull() &&
+		(data.ProviderType.ValueString() == gitHubProviderType ||
+			data.ProviderType.ValueString() == githubEnterpriseType) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("token_issuer"),
+			"Invalid Attribute Configuration",
+			fmt.Sprintf("token_issuer is not allowed when provider_type is set to '%s' or '%s'.", gitHubProviderType, githubEnterpriseType),
+		)
+	}
+
+	if !data.EnablePermissiveConfiguration.IsNull() &&
+		data.ProviderType.ValueString() != gitHubProviderType &&
+		data.ProviderType.ValueString() != githubEnterpriseType {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("enable_permissive_configuration"),
+			"Invalid Attribute Configuration",
+			fmt.Sprintf("enable_permissive_configuration is only applicable when provider_type is set to '%s' or '%s'.", gitHubProviderType, githubEnterpriseType),
+		)
+	}
 }
 
 type oidcConfigurationResourceModel struct {
@@ -227,6 +258,7 @@ type oidcConfigurationResourceModel struct {
 	Audience                      types.String `tfsdk:"audience"`
 	Organization                  types.String `tfsdk:"organization"`
 	ProjectKey                    types.String `tfsdk:"project_key"`
+	TokenIssuer                   types.String `tfsdk:"token_issuer"`
 	AzureAppId                    types.String `tfsdk:"azure_app_id"`
 	UseDefaultProxy               types.Bool   `tfsdk:"use_default_proxy"`
 	EnablePermissiveConfiguration types.Bool   `tfsdk:"enable_permissive_configuration"`
@@ -240,6 +272,7 @@ type oidcConfigurationAPIModel struct {
 	Audience                      string `json:"audience,omitempty"`
 	Organization                  string `json:"organization"`
 	ProjectKey                    string `json:"project_key,omitempty"`
+	TokenIssuer                   string `json:"token_issuer,omitempty"`
 	AzureAppId                    string `json:"azure_app_id,omitempty"`
 	UseDefaultProxy               bool   `json:"use_default_proxy"`
 	EnablePermissiveConfiguration bool   `json:"enable_permissive_configuration,omitempty"`
@@ -269,6 +302,7 @@ func (r *oidcConfigurationResource) Create(ctx context.Context, req resource.Cre
 		Audience:        plan.Audience.ValueString(),
 		Description:     plan.Description.ValueString(),
 		ProjectKey:      plan.ProjectKey.ValueString(),
+		TokenIssuer:     plan.TokenIssuer.ValueString(),
 		UseDefaultProxy: plan.UseDefaultProxy.ValueBool(),
 	}
 
@@ -321,6 +355,13 @@ func (r *oidcConfigurationResource) Create(ctx context.Context, req resource.Cre
 	if response.IsError() {
 		utilfw.UnableToCreateResourceError(resp, response.String())
 		return
+	}
+
+	// token_issuer is Computed — if the user didn't set it, the plan value is unknown.
+	// UseStateForUnknown only replaces unknown when prior state is non-null, so on first
+	// create state is null and the unknown survives. Null it here; Read will populate it.
+	if plan.TokenIssuer.IsUnknown() {
+		plan.TokenIssuer = types.StringNull()
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -388,7 +429,7 @@ func (r *oidcConfigurationResource) Read(ctx context.Context, req resource.ReadR
 		}
 	}
 
-	// Access version 7.144.0 or later is required for the `organization` attribute when `provider_type` is set to `GitHub`
+	// Access version 7.144.0 or later is required for the `organization` attribute when `provider_type` is set to `GitHubEnterprise`
 	if oidcConfig.ProviderType == githubEnterpriseType {
 		if ok, err := util.CheckVersion(r.ProviderData.AccessVersion, GithubEnterpriseAccessVersion); err == nil && ok {
 			if len(oidcConfig.Organization) > 0 {
@@ -415,6 +456,10 @@ func (r *oidcConfigurationResource) Read(ctx context.Context, req resource.ReadR
 	}
 
 	state.UseDefaultProxy = types.BoolValue(oidcConfig.UseDefaultProxy)
+
+	if len(oidcConfig.TokenIssuer) > 0 {
+		state.TokenIssuer = types.StringValue(oidcConfig.TokenIssuer)
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -443,6 +488,7 @@ func (r *oidcConfigurationResource) Update(ctx context.Context, req resource.Upd
 		Audience:        plan.Audience.ValueString(),
 		Description:     plan.Description.ValueString(),
 		ProjectKey:      plan.ProjectKey.ValueString(),
+		TokenIssuer:     plan.TokenIssuer.ValueString(),
 		UseDefaultProxy: plan.UseDefaultProxy.ValueBool(),
 	}
 
@@ -496,6 +542,10 @@ func (r *oidcConfigurationResource) Update(ctx context.Context, req resource.Upd
 	if response.IsError() {
 		utilfw.UnableToUpdateResourceError(resp, response.String())
 		return
+	}
+
+	if plan.TokenIssuer.IsUnknown() {
+		plan.TokenIssuer = types.StringNull()
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)

--- a/pkg/platform/resource_oidc_configuration_test.go
+++ b/pkg/platform/resource_oidc_configuration_test.go
@@ -427,6 +427,88 @@ resource "platform_oidc_configuration" "{{ .name }}" {
 	})
 }
 
+func TestAccOIDCConfiguration_with_token_issuer(t *testing.T) {
+	_, fqrn, configName := testutil.MkNames("test-oidc-token-issuer", "platform_oidc_configuration")
+
+	temp := `
+resource "platform_oidc_configuration" "{{ .name }}" {
+  name          = "{{ .name }}"
+  issuer_url    = "{{ .issuerURL }}"
+  provider_type = "{{ .providerType }}"
+  token_issuer  = "{{ .tokenIssuer }}"
+}`
+
+	testData := map[string]string{
+		"name":         configName,
+		"issuerURL":    "https://tempurl.org",
+		"providerType": "generic",
+		"tokenIssuer":  "https://tempurl.org",
+	}
+
+	config := util.ExecuteTemplate(configName, temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProviders(),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "name", testData["name"]),
+					resource.TestCheckResourceAttr(fqrn, "provider_type", testData["providerType"]),
+					resource.TestCheckResourceAttr(fqrn, "token_issuer", testData["tokenIssuer"]),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        configName,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+		},
+	})
+}
+
+func TestAccOIDCConfiguration_token_issuer_invalid_for_github(t *testing.T) {
+	_, _, configName := testutil.MkNames("test-oidc-token-issuer-invalid", "platform_oidc_configuration")
+
+	temp := `
+resource "platform_oidc_configuration" "{{ .name }}" {
+  name          = "{{ .name }}"
+  issuer_url    = "{{ .issuerURL }}"
+  provider_type = "{{ .providerType }}"
+  organization  = "{{ .organization }}"
+  token_issuer  = "{{ .tokenIssuer }}"
+}`
+
+	for _, providerType := range []string{"GitHub", "GitHubEnterprise"} {
+		issuerURL := "https://token.actions.githubusercontent.com"
+		if providerType == "GitHubEnterprise" {
+			issuerURL = "https://token.actions.githubusercontent.com/jfrog"
+		}
+		testData := map[string]string{
+			"name":         configName,
+			"issuerURL":    issuerURL,
+			"providerType": providerType,
+			"organization": "test-org",
+			"tokenIssuer":  "https://token.actions.githubusercontent.com/test-org",
+		}
+		config := util.ExecuteTemplate(configName, temp, testData)
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProviders(),
+			Steps: []resource.TestStep{
+				{
+					Config:      config,
+					ExpectError: regexp.MustCompile(`token_issuer is not allowed when provider_type is set to`),
+				},
+			},
+		})
+	}
+}
+
 func TestAccOIDCConfiguration_azure(t *testing.T) {
 	_, fqrn, configName := testutil.MkNames("test-oidc-azure-configuration", "platform_oidc_configuration")
 

--- a/sample.tf
+++ b/sample.tf
@@ -17,6 +17,19 @@ provider "platform" {
   // supply JFROG_ACCESS_TOKEN as env var
 }
 
+# Generic OIDC provider with explicit token_issuer (not allowed for GitHub or GitHubEnterprise)
+resource "platform_oidc_configuration" "generic-token-issuer" {
+  name          = "tf-generic-token-issuer"
+  issuer_url    = "https://tempurl.org"
+  provider_type = "generic"
+  audience      = "jfrog-platform"
+  token_issuer  = "https://tempurl.org"
+}
+
+output "generic_token_issuer" {
+  value = platform_oidc_configuration.generic-token-issuer.token_issuer
+}
+
 resource "platform_workers_service" "my-workers-service" {
   key         = "my-workers-service"
   enabled     = true


### PR DESCRIPTION
## Summary

- **New attribute `token_issuer`** (Optional/Computed) on `platform_oidc_configuration`. Allows specifying a custom token issuer URL. Only applicable when `provider_type` is `generic` or `Azure` — blocked for `GitHub` and `GitHubEnterprise` via `ValidateConfig`.
- **`provider_type` now requires replace** — changing provider type changes validation rules, applicable attributes, and API semantics. Allowing in-place updates caused stale state and bypassed type-specific validation. Adding `RequiresReplace` forces a destroy+recreate, which is the correct behaviour.
- **`enable_permissive_configuration` validation** — now enforced in `ValidateConfig` to reject configurations that set this attribute on non-GitHub provider types. Previously the attribute was documented as GitHub-only but was never validated.

## Changes

| File | What changed |
|---|---|
| `pkg/platform/resource_oidc_configuration.go` | `token_issuer` schema + struct fields; `RequiresReplace` on `provider_type`; `ValidateConfig` rules for `token_issuer`, `azure_app_id`, and `enable_permissive_configuration` |
| `pkg/platform/resource_oidc_configuration_test.go` | `TestAccOIDCConfiguration_with_token_issuer` — generic provider, happy path + import; `TestAccOIDCConfiguration_token_issuer_invalid_for_github` — error case for GitHub and GitHubEnterprise |
| `docs/resources/oidc_configuration.md` | Added `token_issuer` to schema reference |
| `examples/resources/platform_oidc_configuration/resource.tf` | Added `token_issuer` to generic example |
| `CHANGELOG.md` | Improvement and upgrade notes for 2.2.11 |
| `sample.tf` | Added generic OIDC block with `token_issuer` for local testing |

## Upgrade impact

| Change | Breaking? | Who is affected |
|---|---|---|
| `token_issuer` new attribute | No | Nobody — Optional/Computed, existing configs unaffected |
| `RequiresReplace` on `provider_type` | Deliberate | Anyone changing `provider_type` in-place — now gets destroy+recreate |
| `token_issuer` validation | No | Nobody — new attribute, no existing config sets it |
| `enable_permissive_configuration` validation | **Yes** | Configs that incorrectly set this on `generic` or `Azure` will fail `terraform plan` and must remove the attribute |

## Test plan

- [ ] `TestAccOIDCConfiguration_with_token_issuer` — creates a `generic` OIDC config with explicit `token_issuer`, verifies value in state and survives import
- [ ] `TestAccOIDCConfiguration_token_issuer_invalid_for_github` — asserts plan-time error when `token_issuer` is set on `GitHub` and `GitHubEnterprise`
- [ ] Existing tests (`_full`, `_with_project`, `_github_enterprise`, `_azure`, `_invalid_*`) pass unchanged


