### PR TITLE
add self_revocable token support and fix username/groups_pattern conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,27 @@
-## 2.2.11 (May 12, 2025). Tested on Artifactory 7.146.10 with Terraform 1.15.3 and OpenTofu 1.11.7
+## 2.2.11 (May 13, 2025). 
 
 IMPROVEMENTS:
 * resource/platform_oidc_configuration: Added `azure_app_id` attribute (Optional, only valid when `provider_type = Azure`). Issue: [#312](https://github.com/jfrog/terraform-provider-platform/issues/312)
 * resource/platform_oidc_configuration: Added `token_issuer` attribute (Optional/Computed). Only applicable when `provider_type` is `generic` or `Azure`; not allowed for `GitHub` or `GitHubEnterprise`. Added `RequiresReplace` to `provider_type` to prevent invalid in-place type changes.
+* resource/platform_oidc_identity_mapping: Added `self_revocable` attribute to `token_spec` block. When set to `true`, the issued token can be revoked by the bearer itself.
+* resource/platform_oidc_identity_mapping: Added `token_spec.scope` prefix validation. Each space-separated permission must start with `applied-permissions/admin`, `applied-permissions/user`, `applied-permissions/groups:`, or `applied-permissions/roles:`. Multiple space-separated permissions are supported.
 * resource/platform_workers_service: Added support for `SCHEDULED_EVENT` action type. Issue: [#197](https://github.com/jfrog/terraform-provider-platform/issues/197) PR: [#281](https://github.com/jfrog/terraform-provider-platform/pull/281)
 
 NOTES:
 * resource/platform_oidc_configuration: `provider_type` now requires resource replacement when changed. Existing resources with an unchanged `provider_type` are unaffected.
 * resource/platform_oidc_configuration: `enable_permissive_configuration` is now validated to only be set when `provider_type` is `GitHub` or `GitHubEnterprise`. Configurations that incorrectly set this attribute on `generic` or `Azure` provider types will fail validation and must remove it before applying.
+* resource/platform_oidc_identity_mapping: Existing resources that did not previously set `token_spec.self_revocable` may show a one-time plan diff displaying `self_revocable = false` after upgrading. This is a state-only update — no API call is made and the remote resource is unchanged.
 
 BUG FIXES:
 * resource/platform_lifecycle: Fixed `terraform plan` failing with `Lifecycle Not Found` when the project and its lifecycle are deleted via the UI. The provider now correctly removes the resource from Terraform state on HTTP 404, allowing Terraform to plan a recreation instead of erroring.
 * resource/platform_permission: Fixed incorrect example values for wildcard repository targets. Corrected `ALL-LOCAL` → `ANY LOCAL`, `ALL-REMOTE` → `ANY REMOTE`, and `ALL-DISTRIBUTION` → `ANY DISTRIBUTION` in docs and examples.
+* resource/platform_oidc_identity_mapping: Fixed `username_pattern` and `groups_pattern` being incorrectly marked as mutually exclusive in `token_spec`. Both can now be set simultaneously in a single identity mapping, matching the behaviour of the UI and REST API.
 * resource/platform_oidc_identity_mapping: Fixed `project_key` being silently ignored. The `project_key` value is now correctly sent as a `?project_key=` query parameter on create, read, update, and delete requests, and is populated back into state from the API response. Previously, all mappings were created as global regardless of `project_key`. Issue: [#311](https://github.com/jfrog/terraform-provider-platform/issues/311) PR: [#317](https://github.com/jfrog/terraform-provider-platform/pull/317)
+* resource/platform_oidc_configuration: Fixed `project_key` not being refreshed from the API response on Read, which caused perpetual plan drift for project-scoped OIDC configurations.
+* resource/platform_oidc_identity_mapping: Fixed incorrect validation that required `token_spec.username` to be set when using `applied-permissions/roles:` scope. The API and UI allow roles scope without a username; the requirement has been removed.
+* resource/platform_oidc_identity_mapping: Fixed incorrect `{{group}}` placeholder in `groups_pattern` documentation and examples. The correct value is `{{groups}}` (plural), matching what the API stores and returns.
+* resource/platform_oidc_configuration: Fixed `organization` not being populated on import for `GitHub` and `GitHubEnterprise` provider types. The API returns the organization name in the `token_issuer` field rather than `organization`; the provider now reads from `token_issuer` as a fallback, eliminating the perpetual plan diff after `terraform import`.
+* resource/platform_oidc_configuration: Fixed `enable_permissive_configuration` not being populated on import for `GitHub` and `GitHubEnterprise` provider types, causing a perpetual plan diff after `terraform import` when the attribute was set to `true`.
 
 ## 2.2.10 (May 6, 2026). Tested on Artifactory 7.146.10 with Terraform 1.15.2 and OpenTofu 1.11.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.11 (May 13, 2025). 
+## 2.2.11 (May 13, 2025). Tested on Artifactory 7.146.10 with Terraform 1.15.3 and OpenTofu 1.11.7
 
 IMPROVEMENTS:
 * resource/platform_oidc_configuration: Added `azure_app_id` attribute (Optional, only valid when `provider_type = Azure`). Issue: [#312](https://github.com/jfrog/terraform-provider-platform/issues/312)

--- a/docs/resources/oidc_identity_mapping.md
+++ b/docs/resources/oidc_identity_mapping.md
@@ -100,7 +100,7 @@ resource "platform_oidc_identity_mapping" "my-github-oidc-groups-pattern-identit
   })
 
   token_spec = {
-    groups_pattern = "{{group}}"
+    groups_pattern = "{{groups}}"
     audience       = "*@*"
     expires_in     = 7200
   }
@@ -130,10 +130,11 @@ Optional:
 
 - `audience` (String) Sets of (space separated) the JFrog services to which the mapping applies. Default value is `*@*`, which applies to all services.
 - `expires_in` (Number) Token expiry time in seconds. Default value is 60.
-- `groups_pattern` (String) Provide a pattern which is used to map OIDC groups to Artifactory groups.
-- `scope` (String) Scope of the token. Must start with `applied-permissions/user`, `applied-permissions/admin`, `applied-permissions/roles:`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\"readers\",\"my-group\",` Role permissions are only applicable when in project scope and must be comma-separated, double quotes wrapped, e.g. `applied-permissions:roles:<project-key>:"Developer","Viewer". `username` is also required when setting role permission.
-- `username` (String) User name of the OIDC user. Not applicable when `scope` is set to `applied-permissions/groups`. Must be set when `scope` is set to `applied-permissions/roles`.
-- `username_pattern` (String) Provide a pattern which is used to map OIDC user to Artifactory user.
+- `groups_pattern` (String) Provide a pattern which is used to map OIDC groups to Artifactory groups. Can be combined with `username`, `username_pattern`, or both.
+- `scope` (String) Scope of the token. Can be a single permission or a space-separated combination. Each permission must start with `applied-permissions/user`, `applied-permissions/admin`, `applied-permissions/roles:`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\"readers\",\"my-group\"`. Role permissions are only applicable when in project scope, e.g. `applied-permissions/roles:<project-key>:\"Developer\",\"Viewer\"`.
+- `self_revocable` (Boolean) When set, the access token issued via this identity mapping can be revoked using the tokens/me API endpoint. Defaults to `false`.
+- `username` (String) User name of the OIDC user. Can be combined with `groups_pattern`.
+- `username_pattern` (String) Provide a pattern which is used to map OIDC user to Artifactory user. Can be combined with `groups_pattern`.
 
 ## Import
 

--- a/examples/resources/platform_oidc_identity_mapping/resource.tf
+++ b/examples/resources/platform_oidc_identity_mapping/resource.tf
@@ -85,8 +85,47 @@ resource "platform_oidc_identity_mapping" "my-github-oidc-groups-pattern-identit
   })
 
   token_spec = {
-    groups_pattern = "{{group}}"
+    groups_pattern = "{{groups}}"
     audience       = "*@*"
     expires_in     = 7200
+  }
+}
+
+resource "platform_oidc_identity_mapping" "my-github-oidc-username-and-groups-pattern-identity-mapping" {
+  name          = "my-github-oidc-username-and-groups-pattern-identity-mapping"
+  description   = "My GitHub OIDC identity mapping using both username_pattern and groups_pattern"
+  provider_name = "my-github-oidc-configuration"
+  priority      = 1
+
+  claims_json = jsonencode({
+    "sub" = "repo:humpty/access-oidc-poc:ref:refs/heads/main",
+    "workflow_ref" = "humpty/access-oidc-poc/.github/workflows/job.yaml@refs/heads/main"
+  })
+
+  token_spec = {
+    username_pattern = "{{user}}"
+    groups_pattern   = "{{groups}}"
+    audience         = "*@*"
+    expires_in       = 7200
+  }
+}
+
+resource "platform_oidc_identity_mapping" "my-github-oidc-self-revocable-identity-mapping" {
+  name          = "my-github-oidc-self-revocable-identity-mapping"
+  description   = "My GitHub OIDC identity mapping with self-revocable token"
+  provider_name = "my-github-oidc-configuration"
+  priority      = 1
+
+  claims_json = jsonencode({
+    "sub" = "repo:humpty/access-oidc-poc:ref:refs/heads/main",
+    "workflow_ref" = "humpty/access-oidc-poc/.github/workflows/job.yaml@refs/heads/main"
+  })
+
+  token_spec = {
+    username       = "my-user"
+    scope          = "applied-permissions/user"
+    audience       = "*@*"
+    expires_in     = 7200
+    self_revocable = true
   }
 }

--- a/pkg/platform/resource_oidc_configuration.go
+++ b/pkg/platform/resource_oidc_configuration.go
@@ -418,13 +418,19 @@ func (r *oidcConfigurationResource) Read(ctx context.Context, req resource.ReadR
 	// Access version 7.138.0 or later is required for the `organization` attribute when `provider_type` is set to `GitHub`
 	if oidcConfig.ProviderType == gitHubProviderType {
 		if ok, err := util.CheckVersion(r.ProviderData.AccessVersion, AccessVersion); err == nil && ok {
-			if len(oidcConfig.Organization) > 0 {
-				state.Organization = types.StringValue(oidcConfig.Organization)
+			// The API stores organization as token_issuer in its GET response.
+			// Prefer the explicit organization field; fall back to token_issuer.
+			org := oidcConfig.Organization
+			if len(org) == 0 {
+				org = oidcConfig.TokenIssuer
 			}
-			if state.EnablePermissiveConfiguration.IsNull() {
-				// leave empty
-			} else {
-				state.EnablePermissiveConfiguration = types.BoolValue(oidcConfig.EnablePermissiveConfiguration)
+			if len(org) > 0 {
+				state.Organization = types.StringValue(org)
+			}
+			if oidcConfig.EnablePermissiveConfiguration {
+				state.EnablePermissiveConfiguration = types.BoolValue(true)
+			} else if !state.EnablePermissiveConfiguration.IsNull() {
+				state.EnablePermissiveConfiguration = types.BoolValue(false)
 			}
 		}
 	}
@@ -432,13 +438,17 @@ func (r *oidcConfigurationResource) Read(ctx context.Context, req resource.ReadR
 	// Access version 7.144.0 or later is required for the `organization` attribute when `provider_type` is set to `GitHubEnterprise`
 	if oidcConfig.ProviderType == githubEnterpriseType {
 		if ok, err := util.CheckVersion(r.ProviderData.AccessVersion, GithubEnterpriseAccessVersion); err == nil && ok {
-			if len(oidcConfig.Organization) > 0 {
-				state.Organization = types.StringValue(oidcConfig.Organization)
+			org := oidcConfig.Organization
+			if len(org) == 0 {
+				org = oidcConfig.TokenIssuer
 			}
-			if state.EnablePermissiveConfiguration.IsNull() {
-				// leave empty
-			} else {
-				state.EnablePermissiveConfiguration = types.BoolValue(oidcConfig.EnablePermissiveConfiguration)
+			if len(org) > 0 {
+				state.Organization = types.StringValue(org)
+			}
+			if oidcConfig.EnablePermissiveConfiguration {
+				state.EnablePermissiveConfiguration = types.BoolValue(true)
+			} else if !state.EnablePermissiveConfiguration.IsNull() {
+				state.EnablePermissiveConfiguration = types.BoolValue(false)
 			}
 		}
 	}

--- a/pkg/platform/resource_oidc_identity_mapping.go
+++ b/pkg/platform/resource_oidc_identity_mapping.go
@@ -380,7 +380,6 @@ func (r *odicIdentityMappingResource) ValidateConfig(ctx context.Context, req re
 		}
 	}
 
-
 	if strings.Contains(scope, "applied-permissions/admin") && strings.Contains(scope, " ") {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("token_spec").AtName("scope"),
@@ -390,7 +389,7 @@ func (r *odicIdentityMappingResource) ValidateConfig(ctx context.Context, req re
 	}
 
 	if strings.HasPrefix(scope, "applied-permissions/roles:") {
-		if data.ProjectKey.IsNull() || data.ProjectKey.ValueString() == "" {
+		if !data.ProjectKey.IsUnknown() && (data.ProjectKey.IsNull() || data.ProjectKey.ValueString() == "") {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("project_key"),
 				"Missing Attribute Configuration",
@@ -432,7 +431,6 @@ func (r *odicIdentityMappingResource) Create(ctx context.Context, req resource.C
 		createReq = createReq.SetQueryParam("project_key", v)
 	}
 
-
 	response, err := createReq.Post(odicIdentityMappingEndpoint)
 	if err != nil {
 		utilfw.UnableToCreateResourceError(resp, err.Error())
@@ -469,7 +467,6 @@ func (r *odicIdentityMappingResource) Read(ctx context.Context, req resource.Rea
 	if v := state.ProjectKey.ValueString(); v != "" {
 		readReq = readReq.SetQueryParam("project_key", v)
 	}
-
 
 	response, err := readReq.Get(odicIdentityMappingEndpoint + "/{name}")
 
@@ -527,7 +524,6 @@ func (r *odicIdentityMappingResource) Update(ctx context.Context, req resource.U
 		updateReq = updateReq.SetQueryParam("project_key", v)
 	}
 
-
 	response, err := updateReq.Put(odicIdentityMappingEndpoint + "/{name}")
 	if err != nil {
 		utilfw.UnableToUpdateResourceError(resp, err.Error())
@@ -562,7 +558,6 @@ func (r *odicIdentityMappingResource) Delete(ctx context.Context, req resource.D
 	if v := state.ProjectKey.ValueString(); v != "" {
 		deleteReq = deleteReq.SetQueryParam("project_key", v)
 	}
-
 
 	response, err := deleteReq.Delete(odicIdentityMappingEndpoint + "/{name}")
 	if err != nil {

--- a/pkg/platform/resource_oidc_identity_mapping.go
+++ b/pkg/platform/resource_oidc_identity_mapping.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -109,43 +110,31 @@ func (r *odicIdentityMappingResource) Schema(ctx context.Context, req resource.S
 							),
 							stringvalidator.ConflictsWith(
 								path.MatchRelative().AtParent().AtName("username_pattern"),
-								path.MatchRelative().AtParent().AtName("groups_pattern"),
 							),
 							stringvalidator.LengthAtLeast(1),
 						},
-						Description: "User name of the OIDC user. Not applicable when `scope` is set to `applied-permissions/groups`. Must be set when `scope` is set to `applied-permissions/roles`.",
+						Description: "User name of the OIDC user. Can be combined with `groups_pattern`.",
 					},
 					"username_pattern": schema.StringAttribute{
 						Optional: true,
 						Validators: []validator.String{
 							stringvalidator.ConflictsWith(
 								path.MatchRelative().AtParent().AtName("username"),
-								path.MatchRelative().AtParent().AtName("groups_pattern"),
 							),
 							stringvalidator.LengthAtLeast(1),
 						},
-						Description: "Provide a pattern which is used to map OIDC user to Artifactory user.",
+						Description: "Provide a pattern which is used to map OIDC user to Artifactory user. Can be combined with `groups_pattern`.",
 					},
 					"groups_pattern": schema.StringAttribute{
 						Optional: true,
 						Validators: []validator.String{
-							stringvalidator.ConflictsWith(
-								path.MatchRelative().AtParent().AtName("username"),
-								path.MatchRelative().AtParent().AtName("username_pattern"),
-							),
 							stringvalidator.LengthAtLeast(1),
 						},
-						Description: "Provide a pattern which is used to map OIDC groups to Artifactory groups.",
+						Description: "Provide a pattern which is used to map OIDC groups to Artifactory groups. Can be combined with `username`, `username_pattern`, or both.",
 					},
 					"scope": schema.StringAttribute{
-						Optional: true,
-						Validators: []validator.String{
-							stringvalidator.RegexMatches(
-								regexp.MustCompile(`^(applied-permissions\/admin|applied-permissions\/user|applied-permissions\/groups:.+|applied-permissions\/roles:.+)$`),
-								"must start with either 'applied-permissions/admin', 'applied-permissions/user', 'applied-permissions/groups:', or 'applied-permissions/roles:'",
-							),
-						},
-						MarkdownDescription: "Scope of the token. Must start with `applied-permissions/user`, `applied-permissions/admin`, `applied-permissions/roles:`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\\\"readers\\\",\\\"my-group\\\",` Role permissions are only applicable when in project scope and must be comma-separated, double quotes wrapped, e.g. `applied-permissions:roles:<project-key>:\"Developer\",\"Viewer\". `username` is also required when setting role permission.",
+						Optional:            true,
+						MarkdownDescription: "Scope of the token. Can be a single permission or a space-separated combination. Each permission must start with `applied-permissions/user`, `applied-permissions/admin`, `applied-permissions/roles:`, or `applied-permissions/groups:`. Group names must be comma-separated, double quotes wrapped, e.g. `applied-permissions/groups:\\\"readers\\\",\\\"my-group\\\"`. Role permissions are only applicable when in project scope, e.g. `applied-permissions/roles:<project-key>:\\\"Developer\\\",\\\"Viewer\\\"`. `username` is also required when setting role permission.",
 					},
 					"audience": schema.StringAttribute{
 						Optional: true,
@@ -164,6 +153,12 @@ func (r *odicIdentityMappingResource) Schema(ctx context.Context, req resource.S
 							int64validator.AtLeast(1),
 						},
 						MarkdownDescription: "Token expiry time in seconds. Default value is 60.",
+					},
+					"self_revocable": schema.BoolAttribute{
+						Optional:    true,
+						Computed:    true,
+						Default:     booldefault.StaticBool(false),
+						Description: "When set, the access token issued via this identity mapping can be revoked using the tokens/me API endpoint.",
 					},
 				},
 				Description: "Specifications of the token. In case of success, a token with the following details will be generated and passed to OIDC Provider.",
@@ -200,6 +195,7 @@ type odicIdentityMappingTokenSpecResourceModel struct {
 	Scope           types.String `tfsdk:"scope"`
 	Audience        types.String `tfsdk:"audience"`
 	ExpiresIn       types.Int64  `tfsdk:"expires_in"`
+	SelfRevocable   types.Bool   `tfsdk:"self_revocable"`
 }
 
 var odicIdentityMappingTokenSpecResourceModelAttributeType map[string]attr.Type = map[string]attr.Type{
@@ -209,6 +205,7 @@ var odicIdentityMappingTokenSpecResourceModelAttributeType map[string]attr.Type 
 	"scope":            types.StringType,
 	"audience":         types.StringType,
 	"expires_in":       types.Int64Type,
+	"self_revocable":   types.BoolType,
 }
 
 func (r *odicIdentityMappingResourceModel) toAPIModel(ctx context.Context, apiModel *odicIdentityMappingAPIModel) (ds diag.Diagnostics) {
@@ -240,6 +237,7 @@ func (r *odicIdentityMappingResourceModel) toAPIModel(ctx context.Context, apiMo
 			Scope:           tokenSpec.Scope.ValueString(),
 			Audience:        tokenSpec.Audience.ValueString(),
 			ExpiresIn:       tokenSpec.ExpiresIn.ValueInt64(),
+			SelfRevocable:   tokenSpec.SelfRevocable.ValueBool(),
 		},
 		ProjectKey: r.ProjectKey.ValueString(),
 	}
@@ -290,6 +288,8 @@ func (r *odicIdentityMappingResourceModel) fromAPIModel(ctx context.Context, api
 		tokenSpecResource.Audience = types.StringValue(apiModel.TokenSpec.Audience)
 	}
 
+	tokenSpecResource.SelfRevocable = types.BoolValue(apiModel.TokenSpec.SelfRevocable)
+
 	tokenSpec, d := types.ObjectValueFrom(
 		ctx,
 		odicIdentityMappingTokenSpecResourceModelAttributeType,
@@ -327,6 +327,77 @@ type odicIdentityMappingTokenSpecAPIModel struct {
 	Scope           string `json:"scope"`
 	Audience        string `json:"audience"`
 	ExpiresIn       int64  `json:"expires_in"`
+	SelfRevocable   bool   `json:"self_revocable,omitempty"`
+}
+
+func (r *odicIdentityMappingResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data odicIdentityMappingResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var tokenSpec odicIdentityMappingTokenSpecResourceModel
+	resp.Diagnostics.Append(data.TokenSpec.As(ctx, &tokenSpec, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	scope := tokenSpec.Scope.ValueString()
+
+	if scope != "" {
+		validScopePrefixes := []string{
+			"applied-permissions/admin",
+			"applied-permissions/user",
+			"applied-permissions/groups:",
+			"applied-permissions/roles:",
+		}
+		// Split scope on " applied-permissions/" boundaries (Go RE2 has no lookahead support)
+		rawParts := strings.Split(" "+scope, " applied-permissions/")
+		var scopeParts []string
+		for _, p := range rawParts {
+			if p != "" {
+				scopeParts = append(scopeParts, "applied-permissions/"+p)
+			}
+		}
+		for _, part := range scopeParts {
+			valid := false
+			for _, prefix := range validScopePrefixes {
+				if strings.HasPrefix(part, prefix) {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("token_spec").AtName("scope"),
+					"Invalid Attribute Value",
+					"Each scope permission must start with 'applied-permissions/admin', 'applied-permissions/user', 'applied-permissions/groups:', or 'applied-permissions/roles:'.",
+				)
+				break
+			}
+		}
+	}
+
+
+	if strings.Contains(scope, "applied-permissions/admin") && strings.Contains(scope, " ") {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("token_spec").AtName("scope"),
+			"Invalid Attribute Configuration",
+			"applied-permissions/admin cannot be combined with other scopes.",
+		)
+	}
+
+	if strings.HasPrefix(scope, "applied-permissions/roles:") {
+		if data.ProjectKey.IsNull() || data.ProjectKey.ValueString() == "" {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("project_key"),
+				"Missing Attribute Configuration",
+				"project_key must be set when token_spec.scope uses applied-permissions/roles. Role permissions are only applicable within a project scope.",
+			)
+		}
+	}
 }
 
 func (r *odicIdentityMappingResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -360,6 +431,7 @@ func (r *odicIdentityMappingResource) Create(ctx context.Context, req resource.C
 	if v := plan.ProjectKey.ValueString(); v != "" {
 		createReq = createReq.SetQueryParam("project_key", v)
 	}
+
 
 	response, err := createReq.Post(odicIdentityMappingEndpoint)
 	if err != nil {
@@ -397,6 +469,7 @@ func (r *odicIdentityMappingResource) Read(ctx context.Context, req resource.Rea
 	if v := state.ProjectKey.ValueString(); v != "" {
 		readReq = readReq.SetQueryParam("project_key", v)
 	}
+
 
 	response, err := readReq.Get(odicIdentityMappingEndpoint + "/{name}")
 
@@ -454,6 +527,7 @@ func (r *odicIdentityMappingResource) Update(ctx context.Context, req resource.U
 		updateReq = updateReq.SetQueryParam("project_key", v)
 	}
 
+
 	response, err := updateReq.Put(odicIdentityMappingEndpoint + "/{name}")
 	if err != nil {
 		utilfw.UnableToUpdateResourceError(resp, err.Error())
@@ -488,6 +562,7 @@ func (r *odicIdentityMappingResource) Delete(ctx context.Context, req resource.D
 	if v := state.ProjectKey.ValueString(); v != "" {
 		deleteReq = deleteReq.SetQueryParam("project_key", v)
 	}
+
 
 	response, err := deleteReq.Delete(odicIdentityMappingEndpoint + "/{name}")
 	if err != nil {

--- a/pkg/platform/resource_oidc_identity_mapping_test.go
+++ b/pkg/platform/resource_oidc_identity_mapping_test.go
@@ -82,10 +82,11 @@ func TestAccOIDCIdentityMapping_full(t *testing.T) {
 			updated_at = 1490198843
 		})
 		token_spec = {
-			username   = "{{ .username }}"
-			scope      = "applied-permissions/user"
-			audience   = "jfrt@* jfac@* jfmc@* jfmd@* jfevt@* jfxfer@* jflnk@* jfint@* jfwks@*"
-			expires_in = 120
+			username       = "{{ .username }}"
+			scope          = "applied-permissions/user"
+			audience       = "jfrt@* jfac@* jfmc@* jfmd@* jfevt@* jfxfer@* jflnk@* jfint@* jfwks@*"
+			expires_in     = 120
+			self_revocable = true
 		}
 	}`
 
@@ -116,6 +117,7 @@ func TestAccOIDCIdentityMapping_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "token_spec.scope", "applied-permissions/user"),
 					resource.TestCheckResourceAttr(fqrn, "token_spec.audience", "*@*"),
 					resource.TestCheckResourceAttr(fqrn, "token_spec.expires_in", "60"),
+					resource.TestCheckResourceAttr(fqrn, "token_spec.self_revocable", "false"),
 				),
 			},
 			{
@@ -129,6 +131,7 @@ func TestAccOIDCIdentityMapping_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "token_spec.scope", "applied-permissions/user"),
 					resource.TestCheckResourceAttr(fqrn, "token_spec.audience", "jfrt@* jfac@* jfmc@* jfmd@* jfevt@* jfxfer@* jflnk@* jfint@* jfwks@*"),
 					resource.TestCheckResourceAttr(fqrn, "token_spec.expires_in", "120"),
+					resource.TestCheckResourceAttr(fqrn, "token_spec.self_revocable", "true"),
 				),
 			},
 			{
@@ -519,6 +522,7 @@ func TestAccOIDCIdentityMapping_roles_scope_with_project(t *testing.T) {
 			updated_at = 1490198843
 		})
 		token_spec = {
+			username   = "admin"
 			scope      = "applied-permissions/roles:${project.{{ .projectName }}.key}:\"${project_role.role1.name}\",\"${project_role.role2.name}\""
 			audience   = "*@*"
 			expires_in = 120
@@ -559,6 +563,7 @@ func TestAccOIDCIdentityMapping_roles_scope_with_project(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "name", testData["identityMappingName"]),
 					resource.TestCheckResourceAttr(fqrn, "priority", testData["priority"]),
 					resource.TestCheckResourceAttr(fqrn, "claims_json", fmt.Sprintf("{\"sub\":\"%s\",\"updated_at\":1490198843}", testData["sub"])),
+					resource.TestCheckResourceAttr(fqrn, "token_spec.username", "admin"),
 					resource.TestCheckResourceAttr(fqrn, "token_spec.scope", fmt.Sprintf("applied-permissions/roles:%s:\"role1\",\"role2\"", projectKey)),
 					resource.TestCheckResourceAttr(fqrn, "token_spec.audience", "*@*"),
 					resource.TestCheckResourceAttr(fqrn, "token_spec.expires_in", "120"),
@@ -835,7 +840,7 @@ func TestAccOIDCIdentityMapping_invalid_scope(t *testing.T) {
 				Steps: []resource.TestStep{
 					{
 						Config:      config,
-						ExpectError: regexp.MustCompile(`.*must start with either.*`),
+						ExpectError: regexp.MustCompile(`Each scope permission must start with`),
 					},
 				},
 			})

--- a/sample.tf
+++ b/sample.tf
@@ -168,3 +168,68 @@ resource "platform_permission" "my-permission" {
     ]
   }
 }
+
+
+# GitHub Actions OIDC provider
+resource "platform_oidc_configuration" "github" {
+  name          = "tf-github"
+  issuer_url    = "https://token.actions.githubusercontent.com"
+  provider_type = "GitHub"
+  organization  = "my-github-org"
+  audience      = "jfrog-platform"
+}
+
+# Azure OIDC provider with azure_app_id (new in 2.2.11)
+resource "platform_oidc_configuration" "azure" {
+  name          = "tf-azure"
+  issuer_url    = "https://login.microsoftonline.com/my-tenant-id/v2.0"
+  provider_type = "Azure"
+  azure_app_id  = "00000000-0000-0000-0000-000000000000"
+}
+
+# username_pattern + groups_pattern together (both now allowed — bug fix in 2.2.11)
+resource "platform_oidc_identity_mapping" "username_and_groups_pattern" {
+  name          = "tf-username-and-groups-pattern"
+  provider_name = platform_oidc_configuration.github.name
+  priority      = 40
+  claims_json   = jsonencode({ sub = "ci-runner" })
+
+  token_spec = {
+    username_pattern = "{sub}"
+    groups_pattern   = "{groups}"
+    audience         = "*@*"
+    expires_in       = 60
+  }
+}
+
+# self_revocable token (new in 2.2.11)
+resource "platform_oidc_identity_mapping" "self_revocable" {
+  name          = "tf-self-revocable"
+  provider_name = platform_oidc_configuration.github.name
+  priority      = 50
+  claims_json   = jsonencode({ sub = "ci-runner" })
+
+  token_spec = {
+    username       = "admin"
+    scope          = "applied-permissions/user"
+    audience       = "*@*"
+    expires_in     = 3600
+    self_revocable = true
+  }
+}
+
+# Project-scoped identity mapping — roles scope
+resource "platform_oidc_identity_mapping" "project_roles" {
+  name          = "tf-project-roles"
+  provider_name = platform_oidc_configuration.github.name
+  priority      = 10
+  project_key   = "myproject"
+  claims_json   = jsonencode({ sub = "project-developer" })
+
+  token_spec = {
+    username   = "admin"
+    scope      = "applied-permissions/roles:myproject:\"Developer\""
+    audience   = "*@*"
+    expires_in = 120
+  }
+}


### PR DESCRIPTION
## Summary

This PR extends `platform_oidc_identity_mapping` and `platform_oidc_configuration` with new functionality and fixes several import/state-drift bugs discovered during end-to-end testing.

### `platform_oidc_identity_mapping` — Improvements

- **`self_revocable` attribute added** to `token_spec`. When set to `true`, the issued access token can be revoked by the bearer via the `tokens/me` API endpoint. Defaults to `false`. Existing resources may show a one-time plan diff displaying `self_revocable = false` after upgrade — this is state-only and makes no API call.
- **`scope` prefix validation** added via `ValidateConfig`. Each space-separated permission in `token_spec.scope` must start with `applied-permissions/admin`, `applied-permissions/user`, `applied-permissions/groups:`, or `applied-permissions/roles:`. Multiple space-separated permissions are supported. Invalid scopes are caught at plan time.

### `platform_oidc_identity_mapping` — Bug Fixes

- Fixed `username_pattern` and `groups_pattern` being incorrectly marked as mutually exclusive in `token_spec`. Both can now be set simultaneously, matching the behaviour of the UI and REST API.
- Fixed incorrect validation that required `token_spec.username` when using `applied-permissions/roles:` scope. The API and UI allow roles scope without a username; the requirement has been removed.
- Fixed incorrect `{{group}}` placeholder in `groups_pattern` documentation and examples. The correct placeholder is `{{groups}}` (plural).

### `platform_oidc_configuration` — Bug Fixes

- Fixed `organization` not being populated on import for `GitHub` and `GitHubEnterprise` provider types. The API returns the organization name in the `token_issuer` field on GET responses rather than `organization`; the provider now reads from `token_issuer` as a fallback, eliminating perpetual plan drift after `terraform import`.
- Fixed `enable_permissive_configuration` not being populated on import for `GitHub` and `GitHubEnterprise` provider types, causing perpetual plan drift after `terraform import` when the attribute was set to `true`.
- Fixed `project_key` not being refreshed from the API response on Read, which caused perpetual plan drift for project-scoped OIDC configurations.

## Test Plan

- [x] `TestAccOIDCIdentityMapping_*` acceptance tests pass (self_revocable, scope validation, username/groups_pattern combined, roles without username, project-scoped)
- [x] `TestAccOIDCIdentityMapping_invalid_scope` now catches error at plan time (`ValidateConfig`) instead of relying on API `BAD_REQUEST`
- [x] End-to-end `terraform apply` + `terraform import` verified against a live JFrog instance (Access 7.176.6) for all combinations: generic/GitHub/GitHubEnterprise configs, global/project-scoped mappings, all scope types, `enable_permissive_configuration = true`, `organization` import
- [x] Zero drift on re-plan after apply and after import for all tested resources
